### PR TITLE
Feat: add capability to generate different framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: build
+
+build:
+	@./script/build.sh

--- a/internal/app/init_project.go
+++ b/internal/app/init_project.go
@@ -35,8 +35,8 @@ func (uc *InitProjectUseCase) Run(p *domain.Project, progressCh chan<- string) e
 	initFuncs := []func() error{
 		// config
 		func() error {
-			progressCh <- "Running gin framework generation"
-			return domain.InitGin(uc.Runner, &p.Path)
+			progressCh <- "Running framework generation"
+			return domain.InitFramework(uc.Runner, &p.Path, &p.Framework)
 		},
 		func() error {
 			progressCh <- "Running env config generation"
@@ -96,11 +96,11 @@ func (uc *InitProjectUseCase) Run(p *domain.Project, progressCh chan<- string) e
 		},
 		func() error {
 			progressCh <- "Running handler example generation"
-			return domain.InitHandlerDomain(uc.Runner, &p.Path)
+			return domain.InitHandlerDomain(uc.Runner, &p.Path, &p.Framework)
 		},
 		func() error {
 			progressCh <- "Running http handler example generation"
-			return domain.InitHTTPHandlerDomain(uc.Runner, &p.Path)
+			return domain.InitHTTPHandlerDomain(uc.Runner, &p.Path, &p.Framework)
 		},
 		func() error {
 			progressCh <- "Running pkg example generation"
@@ -118,7 +118,7 @@ func (uc *InitProjectUseCase) Run(p *domain.Project, progressCh chan<- string) e
 		},
 		func() error {
 			progressCh <- "Running server file generation"
-			return domain.InitServer(uc.Runner, &p.Path)
+			return domain.InitServer(uc.Runner, &p.Path, &p.Framework)
 		},
 		func() error {
 			progressCh <- "Running main file generation"

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -59,6 +59,8 @@ func InitHandlerDomain(i infra.CommandRunner, path *string, framework *string) e
 			t = domain_template.EchoTodoHandlerTemplate
 		case "fiber":
 			t = domain_template.FiberTodoHandlerTemplate
+		case "gorrila/mux":
+			t = domain_template.GorrilaTodoHandlerTemplate
 		}
 		if err := pkg.GoFileGenerator(i, path, folderName, fileName, t); err != nil {
 			log.Fatal(err)
@@ -96,6 +98,8 @@ func InitHTTPHandlerDomain(i infra.CommandRunner, path *string, framework *strin
 			t = domain_template.EchoHTTPHandlerTemplate
 		case "fiber":
 			t = domain_template.FiberHTTPHandlerTemplate
+		case "gorrila/mux":
+			t = domain_template.GorrilaHTTPHandlerTemplate
 		}
 		if err := pkg.GoFileGenerator(i, path, folderName, fileName, t); err != nil {
 			log.Fatal(err)

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -45,11 +45,20 @@ func InitServiceDomain(i infra.CommandRunner, path *string) error {
 	return errors.New("path is nil")
 }
 
-func InitHandlerDomain(i infra.CommandRunner, path *string) error {
+func InitHandlerDomain(i infra.CommandRunner, path *string, framework *string) error {
 	if path != nil {
 		folderName := "/internal/domain/handler"
 		fileName := folderName + "/todo.go"
-		if err := pkg.GoFileGenerator(i, path, folderName, fileName, domain_template.TodoHandlerTemplate); err != nil {
+		var t string
+		switch *framework {
+		case "gin":
+			t = domain_template.GinTodoHandlerTemplate
+		case "chi":
+			t = domain_template.ChiTodoHandlerTemplate
+		case "echo":
+			t = domain_template.EchoTodoHandlerTemplate
+		}
+		if err := pkg.GoFileGenerator(i, path, folderName, fileName, t); err != nil {
 			log.Fatal(err)
 			return err
 		}
@@ -71,11 +80,20 @@ func InitDTODomain(i infra.CommandRunner, path *string) error {
 	return errors.New("path is nil")
 }
 
-func InitHTTPHandlerDomain(i infra.CommandRunner, path *string) error {
+func InitHTTPHandlerDomain(i infra.CommandRunner, path *string, framework *string) error {
 	if path != nil {
 		folderName := "/internal/domain/handler"
 		fileName := folderName + "/http.go"
-		if err := pkg.GoFileGenerator(i, path, folderName, fileName, domain_template.HTTPHandlerTemplate); err != nil {
+		var t string
+		switch *framework {
+		case "gin":
+			t = domain_template.GinHTTPHandlerTemplate
+		case "chi":
+			t = domain_template.ChiHTTPHandlerTemplate
+		case "echo":
+			t = domain_template.EchoHTTPHandlerTemplate
+		}
+		if err := pkg.GoFileGenerator(i, path, folderName, fileName, t); err != nil {
 			log.Fatal(err)
 			return err
 		}

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -57,6 +57,8 @@ func InitHandlerDomain(i infra.CommandRunner, path *string, framework *string) e
 			t = domain_template.ChiTodoHandlerTemplate
 		case "echo":
 			t = domain_template.EchoTodoHandlerTemplate
+		case "fiber":
+			t = domain_template.FiberTodoHandlerTemplate
 		}
 		if err := pkg.GoFileGenerator(i, path, folderName, fileName, t); err != nil {
 			log.Fatal(err)
@@ -92,6 +94,8 @@ func InitHTTPHandlerDomain(i infra.CommandRunner, path *string, framework *strin
 			t = domain_template.ChiHTTPHandlerTemplate
 		case "echo":
 			t = domain_template.EchoHTTPHandlerTemplate
+		case "fiber":
+			t = domain_template.FiberHTTPHandlerTemplate
 		}
 		if err := pkg.GoFileGenerator(i, path, folderName, fileName, t); err != nil {
 			log.Fatal(err)

--- a/internal/domain/framework.go
+++ b/internal/domain/framework.go
@@ -21,6 +21,8 @@ func InitFramework(i infra.CommandRunner, path *string, framework *string) error
 			t = framework_template.ChiConfigTemplate
 		case "echo":
 			t = framework_template.EchoConfigTemplate
+		case "fiber":
+			t = framework_template.FiberConfigTemplate
 		}
 		if err := pkg.GoFileGenerator(i, path, folderName, fileName, t); err != nil {
 			log.Fatal(err)

--- a/internal/domain/framework.go
+++ b/internal/domain/framework.go
@@ -23,6 +23,8 @@ func InitFramework(i infra.CommandRunner, path *string, framework *string) error
 			t = framework_template.EchoConfigTemplate
 		case "fiber":
 			t = framework_template.FiberConfigTemplate
+		case "gorrila/mux":
+			t = framework_template.GorillaMuxConfigTemplate
 		}
 		if err := pkg.GoFileGenerator(i, path, folderName, fileName, t); err != nil {
 			log.Fatal(err)

--- a/internal/domain/framework.go
+++ b/internal/domain/framework.go
@@ -9,11 +9,20 @@ import (
 	framework_template "github.com/daffadon/fndn/internal/template/framework"
 )
 
-func InitGin(i infra.CommandRunner, path *string) error {
+func InitFramework(i infra.CommandRunner, path *string, framework *string) error {
 	if path != nil {
 		folderName := "/config/router"
 		fileName := folderName + "/http.go"
-		if err := pkg.GoFileGenerator(i, path, folderName, fileName, framework_template.GinConfigTemplate); err != nil {
+		var t string
+		switch *framework {
+		case "gin":
+			t = framework_template.GinConfigTemplate
+		case "chi":
+			t = framework_template.ChiConfigTemplate
+		case "echo":
+			t = framework_template.EchoConfigTemplate
+		}
+		if err := pkg.GoFileGenerator(i, path, folderName, fileName, t); err != nil {
 			log.Fatal(err)
 			return err
 		}

--- a/internal/domain/main-gen.go
+++ b/internal/domain/main-gen.go
@@ -35,11 +35,16 @@ func InitBootStrap(i infra.CommandRunner, path *string) error {
 	return errors.New("path is nil")
 }
 
-func InitServer(i infra.CommandRunner, path *string) error {
+func InitServer(i infra.CommandRunner, path *string, fwk *string) error {
 	if path != nil {
 		folderName := "/cmd/server"
 		fileName := folderName + "/server.go"
-		if err := pkg.GoFileGenerator(i, path, folderName, fileName, main_template.HTTPServerTemplate); err != nil {
+		c, err := pkg.HTTPServerParser(*fwk)
+		if err != nil {
+			log.Fatal(err)
+			return err
+		}
+		if err := pkg.GoFileGenerator(i, path, folderName, fileName, c); err != nil {
 			log.Fatal(err)
 			return err
 		}

--- a/internal/domain/project.go
+++ b/internal/domain/project.go
@@ -10,6 +10,7 @@ type Project struct {
 	Path       string
 	Git        bool
 	Air        bool
+	Framework  string
 }
 
 func InitProject(i infra.CommandRunner, path, moduleName string) error {

--- a/internal/pkg/parser.go
+++ b/internal/pkg/parser.go
@@ -26,21 +26,25 @@ func HTTPServerParser(fwk string) (string, error) {
 	case "gin":
 		t.FrameworkImport = `"github.com/gin-gonic/gin"`
 		t.FrameworkRouter = "*gin.Engine"
-		t.RouterHandler = "router"
+		t.RouterHandler = "r"
 	case "chi":
 		t.FrameworkImport = `"github.com/go-chi/chi/v5"`
 		t.FrameworkRouter = "*chi.Mux"
-		t.RouterHandler = "router"
+		t.RouterHandler = "r"
 	case "echo":
 		t.FrameworkImport = `"github.com/labstack/echo/v4"`
 		t.FrameworkRouter = "*echo.Echo"
-		t.RouterHandler = "router"
+		t.RouterHandler = "r"
 	case "fiber":
 		t.FrameworkImport = `"github.com/gofiber/fiber/v2"
 		"github.com/gofiber/fiber/v2/middleware/adaptor"
 		`
 		t.FrameworkRouter = "*fiber.App"
-		t.RouterHandler = "adaptor.FiberApp(router)"
+		t.RouterHandler = "adaptor.FiberApp(r)"
+	case "gorrila/mux":
+		t.FrameworkImport = `"github.com/gorilla/mux"`
+		t.FrameworkRouter = "*mux.Router"
+		t.RouterHandler = "router.WarpWithCors(r)"
 	}
 	return ParseTemplate(main_template.HTTPServerTemplate, t)
 }

--- a/internal/pkg/parser.go
+++ b/internal/pkg/parser.go
@@ -26,12 +26,21 @@ func HTTPServerParser(fwk string) (string, error) {
 	case "gin":
 		t.FrameworkImport = `"github.com/gin-gonic/gin"`
 		t.FrameworkRouter = "*gin.Engine"
+		t.RouterHandler = "router"
 	case "chi":
 		t.FrameworkImport = `"github.com/go-chi/chi/v5"`
 		t.FrameworkRouter = "*chi.Mux"
+		t.RouterHandler = "router"
 	case "echo":
 		t.FrameworkImport = `"github.com/labstack/echo/v4"`
 		t.FrameworkRouter = "*echo.Echo"
+		t.RouterHandler = "router"
+	case "fiber":
+		t.FrameworkImport = `"github.com/gofiber/fiber/v2"
+		"github.com/gofiber/fiber/v2/middleware/adaptor"
+		`
+		t.FrameworkRouter = "*fiber.App"
+		t.RouterHandler = "adaptor.FiberApp(router)"
 	}
 	return ParseTemplate(main_template.HTTPServerTemplate, t)
 }

--- a/internal/pkg/parser.go
+++ b/internal/pkg/parser.go
@@ -44,7 +44,7 @@ func HTTPServerParser(fwk string) (string, error) {
 	case "gorrila/mux":
 		t.FrameworkImport = `"github.com/gorilla/mux"`
 		t.FrameworkRouter = "*mux.Router"
-		t.RouterHandler = "router.WarpWithCors(r)"
+		t.RouterHandler = "router.WarpWithCorsAndLogger(r)"
 	}
 	return ParseTemplate(main_template.HTTPServerTemplate, t)
 }

--- a/internal/pkg/parser.go
+++ b/internal/pkg/parser.go
@@ -3,6 +3,9 @@ package pkg
 import (
 	"bytes"
 	"text/template"
+
+	main_template "github.com/daffadon/fndn/internal/template/main"
+	"github.com/daffadon/fndn/internal/types"
 )
 
 func ParseTemplate(tmplStr string, data interface{}) (string, error) {
@@ -15,4 +18,20 @@ func ParseTemplate(tmplStr string, data interface{}) (string, error) {
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+func HTTPServerParser(fwk string) (string, error) {
+	var t types.HTTPServerParse
+	switch fwk {
+	case "gin":
+		t.FrameworkImport = `"github.com/gin-gonic/gin"`
+		t.FrameworkRouter = "*gin.Engine"
+	case "chi":
+		t.FrameworkImport = `"github.com/go-chi/chi/v5"`
+		t.FrameworkRouter = "*chi.Mux"
+	case "echo":
+		t.FrameworkImport = `"github.com/labstack/echo/v4"`
+		t.FrameworkRouter = "*echo.Echo"
+	}
+	return ParseTemplate(main_template.HTTPServerTemplate, t)
 }

--- a/internal/template/config/framework.yaml.go
+++ b/internal/template/config/framework.yaml.go
@@ -3,10 +3,10 @@ package config_template
 const ServerYamlConfigTemplate string = `
 server:
   cors:
-    allow_origins: "*"
+    allow_origins: "http://localhost"
     allow_methods: "GET,POST,PUT,DELETE,OPTIONS,PATCH"
     allow_headers: "Content-Type,Authorization,X-Requested-With,X-CSRF-Token,Accept,Origin,Cache-Control,X-File-Name,X-File-Type,X-File-Size"
     expose_headers: "Content-Length,Content-Range"
     max_age: 86400
-    allow_credential: true
+    allow_credential: false
 `

--- a/internal/template/domain/handler.go
+++ b/internal/template/domain/handler.go
@@ -1,6 +1,6 @@
 package domain_template
 
-const HTTPHandlerTemplate string = `
+const GinHTTPHandlerTemplate string = `
 package handler
 	
 import "github.com/gin-gonic/gin"
@@ -10,30 +10,21 @@ func RegisterTodoRoutes(r *gin.Engine, th TodoHandler) {
 }
 `
 
-const TodoHandlerTemplate string = `
+const ChiHTTPHandlerTemplate string = `
 package handler
 
-import "github.com/gin-gonic/gin"
+import "github.com/go-chi/chi/v5"
 
-type (
-	TodoHandler interface {
-		// your function definition
-		AddNewTodo(ctx *gin.Context)
-	}
-	todoHandler struct {
-		// your injected dependency
-		// for example
-		ts service.TodoService
-	}
-)
-
-func NewTodoHandler(ts service.TodoService) TodoHandler {
-	return &todoHandler{
-		ts: ts,
-	}
+func RegisterTodoRoutes(r *chi.Mux, th TodoHandler) {
+	r.Post("/todo",th.AddNewTodo)
 }
+`
+const EchoHTTPHandlerTemplate string = `
+package handler
 
-func (t *todoHandler) AddNewTodo(ctx *gin.Context){
-	panic("unimplemented")
+import "github.com/labstack/echo/v4"
+
+func RegisterTodoRoutes(r *echo.Echo, th TodoHandler) {
+	r.POST("/todo",th.AddNewTodo)
 }
 `

--- a/internal/template/domain/handler.go
+++ b/internal/template/domain/handler.go
@@ -38,3 +38,14 @@ func RegisterTodoRoutes(r *fiber.App, th TodoHandler) {
 	r.Post("/todo",th.AddNewTodo)
 }
 `
+
+const GorrilaHTTPHandlerTemplate string = `
+package handler
+
+import "github.com/gorilla/mux"
+
+func RegisterTodoRoutes(r *mux.Router, th TodoHandler) {
+	r.HandleFunc("/todo",th.AddNewTodo).Methods("POST")
+}
+
+`

--- a/internal/template/domain/handler.go
+++ b/internal/template/domain/handler.go
@@ -28,3 +28,13 @@ func RegisterTodoRoutes(r *echo.Echo, th TodoHandler) {
 	r.POST("/todo",th.AddNewTodo)
 }
 `
+
+const FiberHTTPHandlerTemplate string = `
+package handler
+
+import "github.com/gofiber/fiber/v2"
+
+func RegisterTodoRoutes(r *fiber.App, th TodoHandler) {
+	r.Post("/todo",th.AddNewTodo)
+}
+`

--- a/internal/template/domain/service_handler.go
+++ b/internal/template/domain/service_handler.go
@@ -1,0 +1,83 @@
+package domain_template
+
+const GinTodoHandlerTemplate string = `
+package handler
+
+import "github.com/gin-gonic/gin"
+
+type (
+	TodoHandler interface {
+		// your function definition
+		AddNewTodo(ctx *gin.Context)
+	}
+	todoHandler struct {
+		// your injected dependency
+		// for example
+		ts service.TodoService
+	}
+)
+
+func NewTodoHandler(ts service.TodoService) TodoHandler {
+	return &todoHandler{
+		ts: ts,
+	}
+}
+
+func (t *todoHandler) AddNewTodo(ctx *gin.Context){
+	panic("unimplemented")
+}
+`
+
+const ChiTodoHandlerTemplate string = `
+package handler
+
+type (
+	TodoHandler interface {
+		// your function definition
+		AddNewTodo(w http.ResponseWriter, r *http.Request)
+	}
+	todoHandler struct {
+		// your injected dependency
+		// for example
+		ts service.TodoService
+	}
+)
+
+func NewTodoHandler(ts service.TodoService) TodoHandler {
+	return &todoHandler{
+		ts: ts,
+	}
+}
+
+func (t *todoHandler) AddNewTodo(w http.ResponseWriter, r *http.Request){
+	panic("unimplemented")
+}
+`
+
+const EchoTodoHandlerTemplate string = `
+package handler
+
+import "github.com/labstack/echo/v4"
+
+type (
+	TodoHandler interface {
+		// your function definition
+		AddNewTodo(c echo.Context) error
+	}
+	todoHandler struct {
+		// your injected dependency
+		// for example
+		ts service.TodoService
+	}
+)
+
+func NewTodoHandler(ts service.TodoService) TodoHandler {
+	return &todoHandler{
+		ts: ts,
+	}
+}
+
+func (t *todoHandler) AddNewTodo(c echo.Context)error{
+	panic("unimplemented")
+}
+`

--- a/internal/template/domain/service_handler.go
+++ b/internal/template/domain/service_handler.go
@@ -81,3 +81,31 @@ func (t *todoHandler) AddNewTodo(c echo.Context)error{
 	panic("unimplemented")
 }
 `
+
+const FiberTodoHandlerTemplate string = `
+package handler
+
+import "github.com/gofiber/fiber/v2"
+
+type (
+	TodoHandler interface {
+		// your function definition
+		AddNewTodo(c *fiber.Ctx) error
+	}
+	todoHandler struct {
+		// your injected dependency
+		// for example
+		ts service.TodoService
+	}
+)
+
+func NewTodoHandler(ts service.TodoService) TodoHandler {
+	return &todoHandler{
+		ts: ts,
+	}
+}
+
+func (t *todoHandler) AddNewTodo(c *fiber.Ctx)error{
+	panic("unimplemented")
+}
+`

--- a/internal/template/domain/service_handler.go
+++ b/internal/template/domain/service_handler.go
@@ -109,3 +109,29 @@ func (t *todoHandler) AddNewTodo(c *fiber.Ctx)error{
 	panic("unimplemented")
 }
 `
+
+const GorrilaTodoHandlerTemplate string = `
+package handler
+
+type (
+	TodoHandler interface {
+		// your function definition
+		AddNewTodo(w http.ResponseWriter, r *http.Request)
+	}
+	todoHandler struct {
+		// your injected dependency
+		// for example
+		ts service.TodoService
+	}
+)
+
+func NewTodoHandler(ts service.TodoService) TodoHandler {
+	return &todoHandler{
+		ts: ts,
+	}
+}
+
+func (t *todoHandler) AddNewTodo(w http.ResponseWriter, r *http.Request) {
+	panic("unimplemented")
+}
+`

--- a/internal/template/framework/chi.go
+++ b/internal/template/framework/chi.go
@@ -1,0 +1,38 @@
+package framework_template
+
+const ChiConfigTemplate string = `
+package router 
+
+import (
+	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/cors"
+	"github.com/spf13/viper"
+)
+
+func NewHTTP() *chi.Mux{
+	r := chi.NewRouter()
+	env := os.Getenv("ENV")
+	if env != "production" {
+		r.Use(middleware.Logger)
+	}
+
+	allowOrigins := viper.GetString("server.cors.allow_origins")
+	allowMethods := viper.GetString("server.cors.allow_methods")
+	allowHeaders := viper.GetString("server.cors.allow_headers")
+	exposeHeaders := viper.GetString("server.cors.expose_headers")
+	allowCredentials := viper.GetBool("server.cors.allow_credential")
+	maxAge := viper.GetInt("server.cors.max_age")
+
+	r.Use(cors.New(cors.Options{
+		AllowedOrigins:   strings.Split(allowOrigins, ","),
+		AllowedMethods:   strings.Split(allowMethods, ","),
+		AllowedHeaders:   strings.Split(allowHeaders, ","),
+		ExposedHeaders:   strings.Split(exposeHeaders, ","),
+		AllowCredentials: allowCredentials,
+		MaxAge:           maxAge,
+	}).Handler)
+
+	return r
+}
+`

--- a/internal/template/framework/echo.go
+++ b/internal/template/framework/echo.go
@@ -1,0 +1,39 @@
+package framework_template
+
+const EchoConfigTemplate string = `
+package router 
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+func NewHTTP() *echo.Echo {
+	env := os.Getenv("ENV")
+	e := echo.New()
+
+	if env == "production" {
+			e.Debug = false
+			e.HideBanner = true
+			e.HidePort = true
+	}
+
+	allowOrigins := viper.GetString("server.cors.allow_origins")
+	allowMethods := viper.GetString("server.cors.allow_methods")
+	allowHeaders := viper.GetString("server.cors.allow_headers")
+	exposeHeaders := viper.GetString("server.cors.expose_headers")
+	allowCredentials := viper.GetBool("server.cors.allow_credential")
+	maxAge := viper.GetInt("server.cors.max_age")
+
+	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+			AllowOrigins:     strings.Split(allowOrigins, ","),
+			AllowMethods:     strings.Split(allowMethods, ","),
+			AllowHeaders:     strings.Split(allowHeaders, ","),
+			ExposeHeaders:    strings.Split(exposeHeaders, ","),
+			AllowCredentials: allowCredentials,
+			MaxAge:           int(time.Duration(maxAge).Seconds()),
+	}))
+
+	return e
+}
+`

--- a/internal/template/framework/echo.go
+++ b/internal/template/framework/echo.go
@@ -6,16 +6,18 @@ package router
 import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/spf13/viper"
 )
 
 func NewHTTP() *echo.Echo {
 	env := os.Getenv("ENV")
 	e := echo.New()
+	e.Use(middleware.Logger())
 
 	if env == "production" {
-			e.Debug = false
-			e.HideBanner = true
-			e.HidePort = true
+		e.Debug = false
+		e.HideBanner = true
+		e.HidePort = true
 	}
 
 	allowOrigins := viper.GetString("server.cors.allow_origins")
@@ -26,12 +28,12 @@ func NewHTTP() *echo.Echo {
 	maxAge := viper.GetInt("server.cors.max_age")
 
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
-			AllowOrigins:     strings.Split(allowOrigins, ","),
-			AllowMethods:     strings.Split(allowMethods, ","),
-			AllowHeaders:     strings.Split(allowHeaders, ","),
-			ExposeHeaders:    strings.Split(exposeHeaders, ","),
-			AllowCredentials: allowCredentials,
-			MaxAge:           int(time.Duration(maxAge).Seconds()),
+		AllowOrigins:     strings.Split(allowOrigins, ","),
+		AllowMethods:     strings.Split(allowMethods, ","),
+		AllowHeaders:     strings.Split(allowHeaders, ","),
+		ExposeHeaders:    strings.Split(exposeHeaders, ","),
+		AllowCredentials: allowCredentials,
+		MaxAge:           int(time.Duration(maxAge).Seconds()),
 	}))
 
 	return e

--- a/internal/template/framework/fiber.go
+++ b/internal/template/framework/fiber.go
@@ -1,0 +1,38 @@
+package framework_template
+
+const FiberConfigTemplate string = `
+package router
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/cors"
+	"github.com/spf13/viper"
+)
+
+func NewHTTP() *fiber.App {
+	env := os.Getenv("ENV")
+	var config fiber.Config
+	if env == "production" {
+		config.Prefork = true
+	}
+	r := fiber.New(config)
+
+	allowOrigins := viper.GetString("server.cors.allow_origins")
+	allowMethods := viper.GetString("server.cors.allow_methods")
+	allowHeaders := viper.GetString("server.cors.allow_headers")
+	exposeHeaders := viper.GetString("server.cors.expose_headers")
+	allowCredentials := viper.GetBool("server.cors.allow_credential")
+	maxAge := viper.GetInt("server.cors.max_age")
+
+	r.Use(cors.New(cors.Config{
+			AllowOrigins:     allowOrigins,
+			AllowMethods:     allowMethods,
+			AllowHeaders:     allowHeaders,
+			ExposeHeaders:    exposeHeaders,
+			AllowCredentials: allowCredentials,
+			MaxAge:           maxAge,
+	}))
+
+	return r
+}
+`

--- a/internal/template/framework/fiber.go
+++ b/internal/template/framework/fiber.go
@@ -6,6 +6,7 @@ package router
 import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/cors"
+	"github.com/gofiber/fiber/v2/middleware/logger"
 	"github.com/spf13/viper"
 )
 
@@ -16,6 +17,7 @@ func NewHTTP() *fiber.App {
 		config.Prefork = true
 	}
 	r := fiber.New(config)
+	r.Use(logger.New())
 
 	allowOrigins := viper.GetString("server.cors.allow_origins")
 	allowMethods := viper.GetString("server.cors.allow_methods")

--- a/internal/template/framework/gorrila.go
+++ b/internal/template/framework/gorrila.go
@@ -1,0 +1,37 @@
+package framework_template
+
+const GorillaMuxConfigTemplate string = `
+package router
+
+import (
+
+	"github.com/gorilla/mux"
+	"github.com/rs/cors"
+	"github.com/spf13/viper"
+)
+
+func NewHTTP() http.Handler {
+	r := mux.NewRouter()
+	return r
+}
+
+func WarpWithCors(r *mux.Router) http.Handler {
+	allowOrigins := viper.GetString("server.cors.allow_origins")
+	allowMethods := viper.GetString("server.cors.allow_methods")
+	allowHeaders := viper.GetString("server.cors.allow_headers")
+	exposeHeaders := viper.GetString("server.cors.expose_headers")
+	allowCredentials := viper.GetBool("server.cors.allow_credential")
+	maxAge := viper.GetInt("server.cors.max_age")
+
+	c := cors.New(cors.Options{
+		AllowedOrigins:   []string{allowOrigins},
+		AllowedMethods:   []string{allowMethods},
+		AllowedHeaders:   []string{allowHeaders},
+		ExposedHeaders:   []string{exposeHeaders},
+		AllowCredentials: allowCredentials,
+		MaxAge:           maxAge,
+	})
+
+	return c.Handler(r)
+}
+`

--- a/internal/template/framework/gorrila.go
+++ b/internal/template/framework/gorrila.go
@@ -5,17 +5,18 @@ package router
 
 import (
 
+	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
 	"github.com/spf13/viper"
 )
 
-func NewHTTP() http.Handler {
+func NewHTTP() *mux.Router {
 	r := mux.NewRouter()
 	return r
 }
 
-func WarpWithCors(r *mux.Router) http.Handler {
+func WarpWithCorsAndLogger(r *mux.Router) http.Handler {
 	allowOrigins := viper.GetString("server.cors.allow_origins")
 	allowMethods := viper.GetString("server.cors.allow_methods")
 	allowHeaders := viper.GetString("server.cors.allow_headers")
@@ -32,6 +33,7 @@ func WarpWithCors(r *mux.Router) http.Handler {
 		MaxAge:           maxAge,
 	})
 
-	return c.Handler(r)
+	loggedRouter := handlers.LoggingHandler(os.Stdout, r)
+	return c.Handler(loggedRouter)
 }
 `

--- a/internal/template/main/server.go
+++ b/internal/template/main/server.go
@@ -49,7 +49,7 @@ func (s *Server) Run(ctx context.Context) {
 			
 			srv := &http.Server{
 				Addr:              s.Address,
-				Handler:           router,
+				Handler:           {{.RouterHandler}},
 				ReadHeaderTimeout: 5 * time.Second,
 			}
 			go func() {

--- a/internal/template/main/server.go
+++ b/internal/template/main/server.go
@@ -4,7 +4,7 @@ const HTTPServerTemplate string = `
 package server
 
 import (
-	"github.com/gin-gonic/gin"
+	{{.FrameworkImport}}
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nats-io/nats.go"
 	"github.com/redis/go-redis/v9"
@@ -22,7 +22,7 @@ func (s *Server) Run(ctx context.Context) {
 	err := s.Container.Invoke(
 		func(
 			logger zerolog.Logger,
-			router *gin.Engine,
+			router {{.FrameworkRouter}},
 			redis *redis.Client,
 			nc *nats.Conn,
 			pgx *pgxpool.Pool,
@@ -42,12 +42,9 @@ func (s *Server) Run(ctx context.Context) {
 			}()
 			defer pgx.Close()
 			
-			router.Use(gin.Recovery())
-			
 			// you can register your routes here
 			// for the example and implementation, here is the example
 
-			
 			handler.RegisterTodoRoutes(router,th)
 			
 			srv := &http.Server{

--- a/internal/template/main/server.go
+++ b/internal/template/main/server.go
@@ -22,7 +22,7 @@ func (s *Server) Run(ctx context.Context) {
 	err := s.Container.Invoke(
 		func(
 			logger zerolog.Logger,
-			router {{.FrameworkRouter}},
+			r {{.FrameworkRouter}},
 			redis *redis.Client,
 			nc *nats.Conn,
 			pgx *pgxpool.Pool,
@@ -45,7 +45,7 @@ func (s *Server) Run(ctx context.Context) {
 			// you can register your routes here
 			// for the example and implementation, here is the example
 
-			handler.RegisterTodoRoutes(router,th)
+			handler.RegisterTodoRoutes(r,th)
 			
 			srv := &http.Server{
 				Addr:              s.Address,

--- a/internal/types/http_server.go
+++ b/internal/types/http_server.go
@@ -4,5 +4,6 @@ type (
 	HTTPServerParse struct {
 		FrameworkImport string
 		FrameworkRouter string
+		RouterHandler   string
 	}
 )

--- a/internal/types/http_server.go
+++ b/internal/types/http_server.go
@@ -1,0 +1,8 @@
+package types
+
+type (
+	HTTPServerParse struct {
+		FrameworkImport string
+		FrameworkRouter string
+	}
+)

--- a/internal/ui/input_main.go
+++ b/internal/ui/input_main.go
@@ -49,6 +49,16 @@ func newModel(uc *app.InitProjectUseCase, targetDir string) model {
 			Input:    module.NewCheckbox("Init air?", true),
 			Validate: nil,
 		},
+		{
+			Label:    "Generated set of module",
+			Input:    module.NewRadioButton([]string{"Default", "Custom"}, 0),
+			Validate: nil,
+		},
+		{
+			Label:    "Framework",
+			Input:    module.NewRadioButton([]string{"Gin", "Chi", "Echo"}, 0),
+			Validate: nil,
+		},
 	}
 
 	steps[0].Input.Focus()
@@ -83,8 +93,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "ctrl+c", "esc":
 			return m, tea.Quit
-		case "tab":
-			m.nextStep()
 		case "shift+tab":
 			m.prevStep()
 		case "enter":
@@ -99,6 +107,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			if m.current < len(m.steps)-1 {
+				if m.current == 3 && m.steps[3].Input.Value().(string) == "Default" {
+					return m, m.submit()
+				}
 				m.nextStep()
 			} else {
 				return m, m.submit()

--- a/internal/ui/input_main.go
+++ b/internal/ui/input_main.go
@@ -56,7 +56,7 @@ func newModel(uc *app.InitProjectUseCase, targetDir string) model {
 		},
 		{
 			Label:    "Framework",
-			Input:    module.NewRadioButton([]string{"Gin", "Chi", "Echo"}, 0),
+			Input:    module.NewRadioButton([]string{"Gin", "Chi", "Echo", "Fiber"}, 0),
 			Validate: nil,
 		},
 	}

--- a/internal/ui/input_main.go
+++ b/internal/ui/input_main.go
@@ -56,7 +56,7 @@ func newModel(uc *app.InitProjectUseCase, targetDir string) model {
 		},
 		{
 			Label:    "Framework",
-			Input:    module.NewRadioButton([]string{"Gin", "Chi", "Echo", "Fiber"}, 0),
+			Input:    module.NewRadioButton([]string{"Gin", "Chi", "Echo", "Fiber", "Gorrila/mux"}, 0),
 			Validate: nil,
 		},
 	}

--- a/internal/ui/input_utility.go
+++ b/internal/ui/input_utility.go
@@ -81,9 +81,11 @@ func (m *model) viewStep() string {
 		s += style.ErrorStyle.Render(fmt.Sprintf("\n⚠️  %v\n", m.err))
 	}
 
-	if m.current < total-1 {
+	if m.current == 3 && m.steps[3].Input.Value().(string) == "Default" {
+		s += "(Enter to scaffold; Left/Shift+Tab to go back; Esc to cancel)\n"
+	} else if m.current < total-1 {
 		s += "(Enter to continue; Left/Shift+Tab to go back; Esc to cancel)\n"
-	} else if m.current == total-1 || m.steps[3].Input.Value().(string) == "Default" {
+	} else if m.current == total-1 {
 		s += "(Enter to scaffold; Left/Shift+Tab to go back; Esc to cancel)\n"
 	}
 

--- a/internal/ui/module/checkbox.go
+++ b/internal/ui/module/checkbox.go
@@ -11,10 +11,11 @@ import (
 type CheckboxInput struct {
 	label   string
 	checked bool
+	focused bool
 }
 
 func NewCheckbox(label string, initial bool) *CheckboxInput {
-	return &CheckboxInput{label: label, checked: initial}
+	return &CheckboxInput{label: label, checked: initial, focused: false}
 }
 
 func (c *CheckboxInput) Update(msg tea.Msg) (types.Input, tea.Cmd) {
@@ -29,9 +30,15 @@ func (c *CheckboxInput) View() string {
 	if c.checked {
 		mark = style.BlueStyle.Render("x")
 	}
-	return fmt.Sprintf("[%s] %s", mark, c.label)
+
+	arrow := ""
+	if c.focused {
+		arrow = style.ArrowStyle.Render("> ")
+	}
+
+	return arrow + fmt.Sprintf("[%s] %s", mark, c.label)
 }
 
 func (c *CheckboxInput) Value() any { return c.checked }
-func (c *CheckboxInput) Focus()     {}
-func (c *CheckboxInput) Blur()      {}
+func (c *CheckboxInput) Focus()     { c.focused = true }
+func (c *CheckboxInput) Blur()      { c.focused = false }

--- a/internal/ui/module/radio.go
+++ b/internal/ui/module/radio.go
@@ -1,0 +1,107 @@
+package module
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/daffadon/fndn/internal/types"
+	"github.com/daffadon/fndn/internal/ui/style"
+)
+
+type RadioButton struct {
+	options  []string
+	selected int
+	cursor   int
+	focused  bool
+}
+
+func NewRadioButton(options []string, initialSelection int) *RadioButton {
+	if initialSelection < 0 || initialSelection >= len(options) {
+		initialSelection = 0
+	}
+	return &RadioButton{
+		options:  options,
+		selected: initialSelection,
+		cursor:   initialSelection,
+		focused:  false,
+	}
+}
+
+func (r *RadioButton) Update(msg tea.Msg) (types.Input, tea.Cmd) {
+	if !r.focused {
+		return r, nil
+	}
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "up", "k":
+			if r.cursor > 0 {
+				r.cursor--
+			}
+		case "down", "j":
+			if r.cursor < len(r.options)-1 {
+				r.cursor++
+			}
+		case "enter", " ":
+			r.selected = r.cursor
+		}
+	}
+	return r, nil
+}
+
+func (r *RadioButton) View() string {
+	s := ""
+	for i, option := range r.options {
+		// Show arrow for current cursor position when focused
+		cursor := "  "
+		if r.cursor == i && r.focused {
+			cursor = style.ArrowStyle.Render("> ")
+		} else {
+			cursor = "  " // Two spaces to match "> " width
+		}
+
+		// Show selection state
+		checked := " "
+		if r.selected == i {
+			checked = "●"
+		} else {
+			checked = "○"
+		}
+
+		s += cursor + checked + " " + option + "\n"
+	}
+
+	// Add instruction for navigation and selection
+	if r.focused {
+		s += "\n↑↓ to navigate, Space/Enter to choose "
+	}
+
+	return s[:len(s)-1] // Remove trailing newline
+}
+
+func (r *RadioButton) Value() any {
+	if r.selected >= 0 && r.selected < len(r.options) {
+		return r.options[r.selected]
+	}
+	return ""
+}
+
+func (r *RadioButton) Focus() {
+	r.focused = true
+}
+
+func (r *RadioButton) Blur() {
+	r.focused = false
+}
+
+// GetSelectedIndex returns the index of the currently selected option
+func (r *RadioButton) GetSelectedIndex() int {
+	return r.selected
+}
+
+// SetSelected sets the selected option by index
+func (r *RadioButton) SetSelected(index int) {
+	if index >= 0 && index < len(r.options) {
+		r.selected = index
+		r.cursor = index
+	}
+}

--- a/internal/ui/module/text_input.go
+++ b/internal/ui/module/text_input.go
@@ -4,6 +4,7 @@ import (
 	btxt "github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/daffadon/fndn/internal/types"
+	"github.com/daffadon/fndn/internal/ui/style"
 )
 
 type TextInput struct {
@@ -24,7 +25,13 @@ func (i *TextInput) Update(msg tea.Msg) (types.Input, tea.Cmd) {
 	return i, cmd
 }
 
-func (i *TextInput) View() string { return i.ti.View() }
-func (i *TextInput) Value() any   { return i.ti.Value() }
-func (i *TextInput) Focus()       { i.ti.Focus() }
-func (i *TextInput) Blur()        { i.ti.Blur() }
+func (i *TextInput) View() string {
+	arrow := ""
+	if i.ti.Focused() {
+		arrow = style.ArrowStyle.Render("> ")
+	}
+	return arrow + i.ti.View()
+}
+func (i *TextInput) Value() any { return i.ti.Value() }
+func (i *TextInput) Focus()     { i.ti.Focus() }
+func (i *TextInput) Blur()      { i.ti.Blur() }


### PR DESCRIPTION
This pull request introduces multi-framework support to the project initialization flow, allowing users to select between Gin, Chi, Echo, and Fiber frameworks. The codebase is refactored to dynamically generate framework-specific templates for routers, handlers, and server files based on user selection. Additionally, the UI is updated to present framework choices during initialization. 

**Framework selection and propagation:**

* Added a `Framework` field to the `Project` struct and updated the initialization flow to propagate the selected framework to all relevant generation steps (`internal/domain/project.go`, `internal/app/init_project.go`). [[1]](diffhunk://#diff-234c380aa075c33cc312bd6eb28aa0669fe1c0f07eac0a4c76174387530d6b52R13) [[2]](diffhunk://#diff-c22934e1f738caf21192939ea06598f8940a86a79a5f882c39f781bca0e9243aL38-R39) [[3]](diffhunk://#diff-c22934e1f738caf21192939ea06598f8940a86a79a5f882c39f781bca0e9243aL99-R103) [[4]](diffhunk://#diff-c22934e1f738caf21192939ea06598f8940a86a79a5f882c39f781bca0e9243aL121-R121)

**Template generation for multiple frameworks:**

* Refactored handler and HTTP handler domain generation to select and use framework-specific templates for Gin, Chi, Echo, and Fiber (`internal/domain/domain.go`, `internal/template/domain/handler.go`, `internal/template/domain/service_handler.go`). [[1]](diffhunk://#diff-31f0dac3ead01690242c1b3b77aecaedbe6e597da094216d65f95da3d093cc4aL48-R63) [[2]](diffhunk://#diff-31f0dac3ead01690242c1b3b77aecaedbe6e597da094216d65f95da3d093cc4aL74-R100) [[3]](diffhunk://#diff-de2f89dfc2d1e0842eebeaaa292d810872e7de01abf89a2af7128e44fec402afR1-R111) [[4]](diffhunk://#diff-b45f92f2e30c5817b0ddc055af7e70e84dbf1184c356f87a01ec23052f4aa1ecL3-R3) [[5]](diffhunk://#diff-b45f92f2e30c5817b0ddc055af7e70e84dbf1184c356f87a01ec23052f4aa1ecL13-R38)

* Added new router configuration templates for Chi, Echo, and Fiber frameworks (`internal/template/framework/chi.go`, `internal/template/framework/echo.go`, `internal/template/framework/fiber.go`). [[1]](diffhunk://#diff-f821ee6aace2be7bb810ccf866c2685a2bf760ab7659fcf0ad2082611700b933R1-R38) [[2]](diffhunk://#diff-8badbb38a58f55e5f2f7fe8a68e4b7135e06f4b4f7e751558f364ba34a734d37R1-R39) [[3]](diffhunk://#diff-65315f10ed6aff5e9befde4e68232c0a610a317f0409786f3335099e7d40dd5cR1-R38)

* Refactored server file generation to use a parser that injects framework-specific imports, router types, and handler wiring into the server template (`internal/domain/main-gen.go`, `internal/pkg/parser.go`, `internal/template/main/server.go`, `internal/types/http_server.go`). [[1]](diffhunk://#diff-93836cfaa28a56f7754b200bc4378dcde125b81843e58aecbb68de36c79c8d0eL38-R47) [[2]](diffhunk://#diff-0bf7eb746977c182936eb3a52c70c17a199999c061b572e3ad0eb70b46454965R6-R8) [[3]](diffhunk://#diff-0bf7eb746977c182936eb3a52c70c17a199999c061b572e3ad0eb70b46454965R22-R46) [[4]](diffhunk://#diff-0c7fee488c3884c542b24dfa3ddb9d979dedd7cb6f17f826e321adcbee022ba6L7-R7) [[5]](diffhunk://#diff-0c7fee488c3884c542b24dfa3ddb9d979dedd7cb6f17f826e321adcbee022ba6L25-R25) [[6]](diffhunk://#diff-0c7fee488c3884c542b24dfa3ddb9d979dedd7cb6f17f826e321adcbee022ba6L45-R52) [[7]](diffhunk://#diff-c1adc35be76ccdd9af3fe64aec269a2ea092df629cb8497b081a3b8faccbde81R1-R9)

**UI improvements:**

* Updated the initialization UI to include framework selection and module set options, and improved navigation logic for user input (`internal/ui/input_main.go`). [[1]](diffhunk://#diff-32b44241dfb31a25f0edc458fd021779e8a57dd6a3deff43a114e005cefe7410R52-R61) [[2]](diffhunk://#diff-32b44241dfb31a25f0edc458fd021779e8a57dd6a3deff43a114e005cefe7410L86-L87) [[3]](diffhunk://#diff-32b44241dfb31a25f0edc458fd021779e8a57dd6a3deff43a114e005cefe7410R110-R112)

**Build script addition:**

* Added a `build` target to the `Makefile` for easier project compilation (`Makefile`).