### PR TITLE
fix: correct spelling of "gorilla/mux" in templates and documentation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -18,12 +18,12 @@ Bootstrap your Go projects with clean architecture, best practices, and a solid 
 ---
 
 > [!NOTE]
-> v0.1.0 now is stable version and generating one set of application with its driver to 3rd party. in this version, you can generate different framework but still limited to others. furthermore, the generation will cover other configuration for each type.
+> v0.1.1 now is stable, latest version, and generating one set of application with its driver to 3rd party. in this version, you can generate different framework but still limited to others. furthermore, the generation will cover other configuration for each type.
   
 ## 🔥 Get started
 
 ```bash
-go run github.com/daffadon/fndn@v0.1.0 init .
+go run github.com/daffadon/fndn@v0.1.1 init .
 ```
 
 \* . generate in current directory
@@ -31,7 +31,7 @@ go run github.com/daffadon/fndn@v0.1.0 init .
 OR
 
 ```bash
-go run github.com/daffadon/fndn@v0.1.0 --help
+go run github.com/daffadon/fndn@v0.1.1 --help
 ```
 
 to see how can you use the tools
@@ -44,7 +44,7 @@ to see how can you use the tools
 If you want to install the tools to your system, you can either using go install or download the binary in available release:
 
 ```bash
-go install github.com/your-username/fndn@v0.1.0
+go install github.com/your-username/fndn@v0.1.1
 ```
 
 ## 🛠️ Default techstack
@@ -57,7 +57,7 @@ Currently, the generation are in default mode and custom mode with limitation in
 ![](https://img.shields.io/badge/fiber-00ACD7?style=for-the-badge&logo=fiber)
 ![](https://img.shields.io/badge/echo-00AFD1?style=for-the-badge&logo=echo)
 ![](https://img.shields.io/badge/chi-01933F?style=for-the-badge&logo=chi)
-![](https://img.shields.io/badge/gorrila/mux-939292?style=for-the-badge&logo=gorrila)
+![](https://img.shields.io/badge/gorilla/mux-939292?style=for-the-badge&logo=gorilla)
 
 - Database
 
@@ -155,7 +155,7 @@ The folder structure is grouped by its usage:
 1. `cmd`: where the command is exist to running the application. there are several folder, which is for bootstraping, dependency injection, construct the server. `main.go` is the entrypoint for all of those.
 2. `config`: store all the configs; connection to 3rd party, instantiation of an dependency, configuration for http server, and certificate for tls. furthermore you can add more like grpc server config, log emitter, or any other configuration.
 3. `internal`: the place where you put on your app logic business that is not should be exposed. this is special folder for golang cause the module can't be imported from anywhere even when the repository is publicly accessible. [see more](https://go.dev/doc/go1.4#internalpackages)
-4. `script`: this is shell script for build the app. there are thow scripts, one for build the binary and one for build the docker image.
+4. `script`: this is shell script for build the app. there are two scripts, one for build the binary and one for build the docker image.
 
 for the files, there are several files that is generated and you can change for your app:
 

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -59,8 +59,8 @@ func InitHandlerDomain(i infra.CommandRunner, path *string, framework *string) e
 			t = domain_template.EchoTodoHandlerTemplate
 		case "fiber":
 			t = domain_template.FiberTodoHandlerTemplate
-		case "gorrila/mux":
-			t = domain_template.GorrilaTodoHandlerTemplate
+		case "gorilla/mux":
+			t = domain_template.GorillaTodoHandlerTemplate
 		}
 		if err := pkg.GoFileGenerator(i, path, folderName, fileName, t); err != nil {
 			log.Fatal(err)
@@ -98,8 +98,8 @@ func InitHTTPHandlerDomain(i infra.CommandRunner, path *string, framework *strin
 			t = domain_template.EchoHTTPHandlerTemplate
 		case "fiber":
 			t = domain_template.FiberHTTPHandlerTemplate
-		case "gorrila/mux":
-			t = domain_template.GorrilaHTTPHandlerTemplate
+		case "gorilla/mux":
+			t = domain_template.GorillaHTTPHandlerTemplate
 		}
 		if err := pkg.GoFileGenerator(i, path, folderName, fileName, t); err != nil {
 			log.Fatal(err)

--- a/internal/domain/framework.go
+++ b/internal/domain/framework.go
@@ -23,7 +23,7 @@ func InitFramework(i infra.CommandRunner, path *string, framework *string) error
 			t = framework_template.EchoConfigTemplate
 		case "fiber":
 			t = framework_template.FiberConfigTemplate
-		case "gorrila/mux":
+		case "gorilla/mux":
 			t = framework_template.GorillaMuxConfigTemplate
 		}
 		if err := pkg.GoFileGenerator(i, path, folderName, fileName, t); err != nil {

--- a/internal/pkg/parser.go
+++ b/internal/pkg/parser.go
@@ -41,7 +41,7 @@ func HTTPServerParser(fwk string) (string, error) {
 		`
 		t.FrameworkRouter = "*fiber.App"
 		t.RouterHandler = "adaptor.FiberApp(r)"
-	case "gorrila/mux":
+	case "gorilla/mux":
 		t.FrameworkImport = `"github.com/gorilla/mux"`
 		t.FrameworkRouter = "*mux.Router"
 		t.RouterHandler = "router.WarpWithCorsAndLogger(r)"

--- a/internal/template/domain/handler.go
+++ b/internal/template/domain/handler.go
@@ -39,7 +39,7 @@ func RegisterTodoRoutes(r *fiber.App, th TodoHandler) {
 }
 `
 
-const GorrilaHTTPHandlerTemplate string = `
+const GorillaHTTPHandlerTemplate string = `
 package handler
 
 import "github.com/gorilla/mux"

--- a/internal/template/domain/service_handler.go
+++ b/internal/template/domain/service_handler.go
@@ -110,7 +110,7 @@ func (t *todoHandler) AddNewTodo(c *fiber.Ctx)error{
 }
 `
 
-const GorrilaTodoHandlerTemplate string = `
+const GorillaTodoHandlerTemplate string = `
 package handler
 
 type (

--- a/internal/ui/input_main.go
+++ b/internal/ui/input_main.go
@@ -56,7 +56,7 @@ func newModel(uc *app.InitProjectUseCase, targetDir string) model {
 		},
 		{
 			Label:    "Framework",
-			Input:    module.NewRadioButton([]string{"Gin", "Chi", "Echo", "Fiber", "Gorrila/mux"}, 0),
+			Input:    module.NewRadioButton([]string{"Gin", "Chi", "Echo", "Fiber", "Gorilla/mux"}, 0),
 			Validate: nil,
 		},
 	}


### PR DESCRIPTION
This pull request primarily addresses a typo in the framework name "gorrila/mux" by correcting it to "gorilla/mux" throughout the codebase and documentation. Additionally, it updates the referenced version of the tool from v0.1.0 to v0.1.1 in the `README.MD` and fixes a minor spelling error in the documentation. These changes improve clarity and consistency for users and developers.

Framework name correction:

* Corrected all instances of "gorrila/mux" to "gorilla/mux" in code logic, templates, and user input options, ensuring consistent naming and proper integration with the Gorilla Mux library. [[1]](diffhunk://#diff-31f0dac3ead01690242c1b3b77aecaedbe6e597da094216d65f95da3d093cc4aL62-R63) [[2]](diffhunk://#diff-31f0dac3ead01690242c1b3b77aecaedbe6e597da094216d65f95da3d093cc4aL101-R102) [[3]](diffhunk://#diff-7c496f4981b7e5a916799d5e8d13c555f9714736d79d94337746f9cbdcf4581bL26-R26) [[4]](diffhunk://#diff-0bf7eb746977c182936eb3a52c70c17a199999c061b572e3ad0eb70b46454965L44-R44) [[5]](diffhunk://#diff-b45f92f2e30c5817b0ddc055af7e70e84dbf1184c356f87a01ec23052f4aa1ecL42-R42) [[6]](diffhunk://#diff-de2f89dfc2d1e0842eebeaaa292d810872e7de01abf89a2af7128e44fec402afL113-R113) [[7]](diffhunk://#diff-32b44241dfb31a25f0edc458fd021779e8a57dd6a3deff43a114e005cefe7410L59-R59)

Documentation updates:

* Updated the tool version references from v0.1.0 to v0.1.1 in `README.MD` to reflect the latest stable release. [[1]](diffhunk://#diff-01e6d9ffed056a02cae8d8a0ec5d476a64d017bf85c0d5a94bb23ca21f33f5aaL21-R34) [[2]](diffhunk://#diff-01e6d9ffed056a02cae8d8a0ec5d476a64d017bf85c0d5a94bb23ca21f33f5aaL47-R47)
* Fixed a spelling error in the folder description, changing "thow scripts" to "two scripts" for improved readability.
* Corrected the badge label and logo for Gorilla Mux in the documentation for accuracy.