### PR TITLE
Feat: Add ClickHouse option in DB choice

### DIFF
--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -35,6 +35,8 @@ func InitYamlConfig(i infra.CommandRunner, p *Project) error {
 			s += config_template.PostresqlYamlConfigTemplate
 		case "mariadb":
 			s += config_template.MariaDBYamlConfigTemplate
+		case "clickhouse":
+			s += config_template.ClickHouseYamlConfigTemplate
 		case "mongodb":
 			s += config_template.MongoDBYamlConfigTemplate
 		case "ferretdb":

--- a/internal/domain/database.go
+++ b/internal/domain/database.go
@@ -20,6 +20,9 @@ func InitDBConfig(i infra.CommandRunner, path *string, db *string) error {
 		case "mariadb":
 			fileName = folderName + "/mariadb.go"
 			template = database_template.MariaDBConfigTemplate
+		case "clickhouse":
+			fileName = folderName + "/clickhouse.go"
+			template = database_template.ClickHouseConfigTemplate
 		case "mongodb":
 			fileName = folderName + "/mongodb.go"
 			template = database_template.MongoDBConfigTemplate

--- a/internal/domain/docker.go
+++ b/internal/domain/docker.go
@@ -56,6 +56,8 @@ func InitDockerComposeConfig(i infra.CommandRunner, p *Project) error {
 			dbDockerTemplate = database_template.DockerComposePostgresqlConfigTemplate
 		case "mariadb":
 			dbDockerTemplate = database_template.DockerComposeMariaDBConfigTemplate
+		case "clickhouse":
+			dbDockerTemplate = database_template.DockerComposeClickHouseConfigTemplate
 		case "mongodb":
 			dbDockerTemplate = database_template.DockerComposeMongoDBConfigTemplate
 		case "ferretdb":

--- a/internal/domain/infra.go
+++ b/internal/domain/infra.go
@@ -19,6 +19,8 @@ func InitQuerierInfra(i infra.CommandRunner, path *string, database *string) err
 			s = infra_template.QuerierPgxInfraTemplate
 		case "mariadb":
 			s = infra_template.QuerierMariaDBInfraTemplate
+		case "clickhouse":
+			s = infra_template.QuerierClickHouseInfraTemplate
 		case "mongodb", "ferretdb":
 			st := struct{ DatabaseName string }{DatabaseName: "database_name"}
 			tmp, err := pkg.ParseTemplate(infra_template.QuerierMongoDBInfraTemplate, st)

--- a/internal/domain/main-gen.go
+++ b/internal/domain/main-gen.go
@@ -19,7 +19,7 @@ func InitDependencyInjection(i infra.CommandRunner, p *Project) error {
 			MQInfra      string
 		}
 		switch p.Database {
-		case "postgresql", "mariadb":
+		case "postgresql", "mariadb", "clickhouse":
 			st.DBConnection = "NewSQLConn"
 		case "neo4j":
 			st.DBConnection = "NewGraphDBConn"

--- a/internal/pkg/parser.go
+++ b/internal/pkg/parser.go
@@ -56,6 +56,10 @@ func HTTPServerParser(fwk, db, mq string) (string, error) {
 		t.DBInstanceType = "*sql.DB"
 		t.DBCloseConnection = "db.Close()"
 		t.DBImport = `"database/sql"`
+	case "clickhouse":
+		t.DBInstanceType = "clickhouse.Conn"
+		t.DBCloseConnection = "db.Close()"
+		t.DBImport = `"github.com/ClickHouse/clickhouse-go/v2"`
 	case "mongodb", "ferretdb":
 		t.DBInstanceType = "*mongo.Client"
 		t.DBCloseConnection = "db.Disconnect(ctx)"

--- a/internal/template/config/db.yaml.go
+++ b/internal/template/config/db.yaml.go
@@ -21,6 +21,16 @@ database:
     port: "3306"
     name: "database_name"
 `
+const ClickHouseYamlConfigTemplate string = `
+database:
+  sql:
+    host: "localhost"
+    user: "myusername"
+    password: "password"
+    port: "9002"
+    name: "database_name"
+    debug: true
+`
 
 const MongoDBYamlConfigTemplate string = `
 database:

--- a/internal/template/database/clickhouse.go
+++ b/internal/template/database/clickhouse.go
@@ -1,0 +1,50 @@
+package database_template
+
+const ClickHouseConfigTemplate string = `
+package storage
+
+import (
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rs/zerolog"
+	"github.com/spf13/viper"
+)
+
+func NewSQLConn(logger zerolog.Logger) clickhouse.Conn {
+	addr := fmt.Sprintf("%s:%s", viper.GetString("database.sql.host"), viper.GetString("database.sql.port"))
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{addr},
+		Auth: clickhouse.Auth{
+			Database: viper.GetString("database.sql.name"),
+			Username: viper.GetString("database.sql.user"),
+			Password: viper.GetString("database.sql.password"),
+		},
+		TLS:         nil,
+		DialTimeout: 5_000_000_000,
+		Debug:       viper.GetBool("database.sql.debug"),
+	})
+	if err != nil {
+		logger.Fatal().Msgf("failed to open ClickHouse connection: %v", err)
+	}
+	if err := conn.Ping(context.Background()); err != nil {
+		log.Fatalf("failed to ping ClickHouse: %v", err)
+	}
+	return conn
+}
+`
+
+const DockerComposeClickHouseConfigTemplate string = `
+# db
+	{{.ProjectName}}_db:
+			image: clickhouse:25.9.4.58-jammy
+			container_name: {{.ProjectName}}_db
+			restart: unless-stopped
+			environment:
+				CLICKHOUSE_DB: ${DB_NAME}
+				CLICKHOUSE_USER: ${DB_USER}
+				CLICKHOUSE_PASSWORD: ${DB_PASSWORD}
+			ports:
+				- "9002:9000"
+			volumes:
+			- {{.ProjectName}}_db_data:/var/lib/clickhouse
+`

--- a/internal/ui/input_main.go
+++ b/internal/ui/input_main.go
@@ -61,12 +61,12 @@ func newModel(uc *app.InitProjectUseCase, targetDir string) model {
 		},
 		{
 			Label:    "Database",
-			Input:    module.NewRadioButton([]string{"Postgresql", "MariaDB", "MongoDB", "FerretDB", "Neo4j"}, 0),
+			Input:    module.NewRadioButton([]string{"Postgresql", "MariaDB", "ClickHouse", "MongoDB", "FerretDB", "Neo4j"}, 0),
 			Validate: nil,
 		},
 		{
 			Label:    "Message Queue",
-			Input:    module.NewRadioButton([]string{"Nats", "RabbitMQ", "Kafka","Amazon SQS"}, 0),
+			Input:    module.NewRadioButton([]string{"Nats", "RabbitMQ", "Kafka", "Amazon SQS"}, 0),
 			Validate: nil,
 		},
 	}


### PR DESCRIPTION
This pull request adds comprehensive support for ClickHouse as a database option throughout the codebase. The changes ensure that ClickHouse can be selected, configured, and used in generated projects, including configuration files, dependency injection, Docker Compose, and infrastructure templates.

**ClickHouse integration across the codebase:**

* Added ClickHouse as a selectable database in the UI (`internal/ui/input_main.go`).
* Updated dependency injection logic to support ClickHouse connections (`internal/domain/main-gen.go`).

**Configuration and templates:**

* Introduced ClickHouse YAML configuration template (`internal/template/config/db.yaml.go`) and integrated it into config generation (`internal/domain/config.go`). [[1]](diffhunk://#diff-1f7236adb72a87b5e8c6fc5efd6637a01e7404a74f1297bc4edfb35d2ba4daebR24-R33) [[2]](diffhunk://#diff-a4f968b05e19215e42106153851095c6d617894089bfc27b0a213f6a3bc6b991R38-R39)
* Added ClickHouse database config and Docker Compose templates (`internal/template/database/clickhouse.go`), and included them in database and Docker Compose initialization (`internal/domain/database.go`, `internal/domain/docker.go`). [[1]](diffhunk://#diff-1c577b198d458431d10523b9f99c1b836e1173d020662aea49a671993fcf1a37R1-R50) [[2]](diffhunk://#diff-9332dcfdeb03d775837361ed7e0429a287a62d1f703f2c3edb71571f5a1f6a71R23-R25) [[3]](diffhunk://#diff-b84348623444c5901ab6ffe428f885f3f335e85047b38480bec0b46b8ec59a74R59-R60)

**Infrastructure and code generation:**

* Implemented ClickHouse querier infrastructure template and integrated it into infra generation (`internal/template/infra/querier.go`, `internal/domain/infra.go`). [[1]](diffhunk://#diff-299b4cc7c8076e5f513427644112091e97faf54186efa172daf38ad4e7efc733R192-R243) [[2]](diffhunk://#diff-a2c2968a31978840a5c22b99fc6fd8a9f2e0abfbba8174efdf9d6e932165881bR22-R23)
* Updated server parser logic to handle ClickHouse-specific imports and connection handling (`internal/pkg/parser.go`).