### PR TITLE
Feat: Add in-memory storage option to custom mode

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,6 +55,7 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+      - '^Merge pull request'
 
 release:
   footer: >-

--- a/README.MD
+++ b/README.MD
@@ -196,9 +196,10 @@ main.go -> bootstrap/bootstrap.go -> di/di.go ---|----> internal/domain/*.go (ex
 ### Air is not working on wsl
 
 > [!NOTE]
-> If you use windows and generate the project using wsl, the hot reload won't work. better you use the fndn for windows in this case or if its already generated, you can change the .air.toml in **cmd part** to become like below and **run air from windows**, not from wsl.
+> If you use windows and generate the project using wsl, the hot reload won't work. better you use the fndn for windows in this case or if its already generated, you can change the .air.toml in `bin and cmd` to become like below and **run air from windows**, not from wsl.
 >
 > ```yml
+> bin = "./tmp/main.exe"
 > cmd = "go build -o ./tmp/main.exe ./cmd"
 > ```
 

--- a/internal/app/init_project.go
+++ b/internal/app/init_project.go
@@ -69,7 +69,7 @@ func (uc *InitProjectUseCase) Run(p *domain.Project, progressCh chan<- string) e
 			return domain.InitQuerierInfra(uc.Runner, p.Path, &p.Database)
 		},
 		func() error {
-			progressCh <- "Running redis infra generation"
+			progressCh <- "Running in-memory infra generation"
 			return domain.InitInMemoryInfra(uc.Runner, p.Path, &p.InMemory)
 		},
 		func() error {

--- a/internal/app/init_project.go
+++ b/internal/app/init_project.go
@@ -47,20 +47,20 @@ func (uc *InitProjectUseCase) Run(p *domain.Project, progressCh chan<- string) e
 			return domain.InitZerologConfig(uc.Runner, p.Path)
 		},
 		func() error {
-			progressCh <- "Running redis config generation"
-			return domain.InitRedisConfig(uc.Runner, p.Path)
+			progressCh <- "Running DB config generation"
+			return domain.InitDBConfig(uc.Runner, p.Path, &p.Database)
 		},
 		func() error {
 			progressCh <- "Running mq config generation"
 			return domain.InitMQConfig(uc.Runner, p)
 		},
 		func() error {
-			progressCh <- "Running minio config generation"
-			return domain.InitMinioConfig(uc.Runner, p.Path)
+			progressCh <- "Running in-memory store config generation"
+			return domain.InitInMemoryConfig(uc.Runner, p.Path, &p.InMemory)
 		},
 		func() error {
-			progressCh <- "Running postgresql config generation"
-			return domain.InitDBConfig(uc.Runner, p.Path, &p.Database)
+			progressCh <- "Running minio config generation"
+			return domain.InitMinioConfig(uc.Runner, p.Path)
 		},
 
 		// infra
@@ -70,7 +70,7 @@ func (uc *InitProjectUseCase) Run(p *domain.Project, progressCh chan<- string) e
 		},
 		func() error {
 			progressCh <- "Running redis infra generation"
-			return domain.InitRedisInfra(uc.Runner, p.Path)
+			return domain.InitInMemoryInfra(uc.Runner, p.Path, &p.InMemory)
 		},
 		func() error {
 			progressCh <- "Running mq infra generation"
@@ -149,6 +149,10 @@ func (uc *InitProjectUseCase) Run(p *domain.Project, progressCh chan<- string) e
 		func() error {
 			progressCh <- "Running mq config file generation"
 			return domain.InitMQConfigFile(uc.Runner, p)
+		},
+		func() error {
+			progressCh <- "Running cache config file generation"
+			return domain.InitInMemoryConfigFile(uc.Runner, p)
 		},
 		func() error {
 			progressCh <- "Running .env.example file generation"

--- a/internal/domain/cache.go
+++ b/internal/domain/cache.go
@@ -9,13 +9,47 @@ import (
 	cache_template "github.com/daffadon/fndn/internal/template/cache"
 )
 
-func InitRedisConfig(i infra.CommandRunner, path *string) error {
+func InitInMemoryConfig(i infra.CommandRunner, path *string, inMemory *string) error {
 	if path != nil {
 		folderName := "/config/cache"
-		fileName := folderName + "/redis.go"
-		if err := pkg.GoFileGenerator(i, path, folderName, fileName, cache_template.RedisConfigTemplate); err != nil {
+		var template, fileName string
+		switch *inMemory {
+		case "redis":
+			fileName = folderName + "/redis.go"
+			template = cache_template.RedisConfigTemplate
+		case "valkey":
+			fileName = folderName + "/valkey.go"
+			template = cache_template.ValkeyConfigTemplate
+		case "keydb":
+			fileName = folderName + "/keydb.go"
+			// template = cache_template.RedisConfigTemplate
+		case "dragonfly":
+			fileName = folderName + "/dragonfly.go"
+			// template = cache_template.RedisConfigTemplate
+		}
+		if err := pkg.GoFileGenerator(i, path, folderName, fileName, template); err != nil {
 			log.Fatal(err)
 			return err
+		}
+		return nil
+	}
+	return errors.New("path is nil")
+}
+
+func InitInMemoryConfigFile(i infra.CommandRunner, p *Project) error {
+	if p.Path != nil {
+		folderName := "/config/cache"
+		var fileName, template string
+		switch p.InMemory {
+		case "valkey":
+			fileName = folderName + "/valkey.acl"
+			template = cache_template.ValkeyConfigFileTemplate
+		}
+		if fileName != "" || template != "" {
+			if err := pkg.GenericFileGenerator(i, p.Path, folderName, fileName, template); err != nil {
+				log.Fatal(err)
+				return err
+			}
 		}
 		return nil
 	}

--- a/internal/domain/cache.go
+++ b/internal/domain/cache.go
@@ -20,16 +20,15 @@ func InitInMemoryConfig(i infra.CommandRunner, path *string, inMemory *string) e
 		case "valkey":
 			fileName = folderName + "/valkey.go"
 			template = cache_template.ValkeyConfigTemplate
-		case "keydb":
-			fileName = folderName + "/keydb.go"
-			// template = cache_template.RedisConfigTemplate
 		case "dragonfly":
 			fileName = folderName + "/dragonfly.go"
-			// template = cache_template.RedisConfigTemplate
+			template = cache_template.DragonflyConfigTemplate
 		}
-		if err := pkg.GoFileGenerator(i, path, folderName, fileName, template); err != nil {
-			log.Fatal(err)
-			return err
+		if fileName != "" || template != "" {
+			if err := pkg.GoFileGenerator(i, path, folderName, fileName, template); err != nil {
+				log.Fatal(err)
+				return err
+			}
 		}
 		return nil
 	}

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -50,6 +50,8 @@ func InitYamlConfig(i infra.CommandRunner, p *Project) error {
 			s += config_template.RedisYamlConfigTemplate
 		case "valkey":
 			s += config_template.ValkeyYamlConfigTemplate
+		case "dragonfly":
+			s += config_template.DragonFlyYamlConfigTemplate
 		}
 
 		switch p.MQ {

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -45,7 +45,12 @@ func InitYamlConfig(i infra.CommandRunner, p *Project) error {
 			s += config_template.Neo4JYamlConfigTemplate
 		}
 		s += config_template.AppYamlConfigTemplate
-		s += config_template.RedisYamlConfigTemplate
+		switch p.InMemory {
+		case "redis":
+			s += config_template.RedisYamlConfigTemplate
+		case "valkey":
+			s += config_template.ValkeyYamlConfigTemplate
+		}
 
 		switch p.MQ {
 		case "nats":

--- a/internal/domain/docker.go
+++ b/internal/domain/docker.go
@@ -86,6 +86,9 @@ func InitDockerComposeConfig(i infra.CommandRunner, p *Project) error {
 		case "valkey":
 			cacheDockerTemplate = cache_template.DockerComposeValkeyConfigTemplate
 			cacheVolumeTemplate = cache_template.DockerComposeValkeyVolumeTemplate
+		case "dragonfly":
+			cacheDockerTemplate = cache_template.DockerComposeDragonflyConfigTemplate
+			cacheVolumeTemplate = cache_template.DockerComposeDragonflyVolumeTemplate
 		}
 
 		templates := []string{

--- a/internal/domain/docker.go
+++ b/internal/domain/docker.go
@@ -48,9 +48,6 @@ func InitDockerComposeConfig(i infra.CommandRunner, p *Project) error {
 		}
 		var results []string
 		var dbDockerTemplate string
-		var mqDockerTemplate string
-		var mqVolumetemplate string
-
 		switch p.Database {
 		case "postgresql":
 			dbDockerTemplate = database_template.DockerComposePostgresqlConfigTemplate
@@ -66,6 +63,8 @@ func InitDockerComposeConfig(i infra.CommandRunner, p *Project) error {
 			dbDockerTemplate = database_template.DockerComposeNeo4JConfigTemplate
 		}
 
+		var mqDockerTemplate string
+		var mqVolumetemplate string
 		switch p.MQ {
 		case "nats":
 			mqDockerTemplate = mq_template.DockerComposeNatsConfigTemplate
@@ -76,19 +75,30 @@ func InitDockerComposeConfig(i infra.CommandRunner, p *Project) error {
 		case "kafka":
 			mqDockerTemplate = mq_template.DockerComposeKafkaConfigTemplate
 			mqVolumetemplate = mq_template.DockerComposeKafkaVolumeTemplate
-
 		}
+
+		var cacheDockerTemplate string
+		var cacheVolumeTemplate string
+		switch p.InMemory {
+		case "redis":
+			cacheDockerTemplate = cache_template.DockerComposeRedisConfigTemplate
+			cacheVolumeTemplate = cache_template.DockerComposeRedisVolumeTemplate
+		case "valkey":
+			cacheDockerTemplate = cache_template.DockerComposeValkeyConfigTemplate
+			cacheVolumeTemplate = cache_template.DockerComposeValkeyVolumeTemplate
+		}
+
 		templates := []string{
 			config_template.DockerComposeAppConfigTemplate,
 			dbDockerTemplate,
 			mqDockerTemplate,
-			cache_template.DockerComposeRedisConfigTemplate,
+			cacheDockerTemplate,
 			objectstorage_template.DockerComposeMinioConfigTemplate,
 
 			// volume
 			database_template.DockerComposeDBVolumeTemplate,
 			mqVolumetemplate,
-			cache_template.DockerComposeRedisVolumeTemplate,
+			cacheVolumeTemplate,
 			objectstorage_template.DockerComposeMinioVolumeTemplate,
 		}
 		for _, tpl := range templates {

--- a/internal/domain/infra.go
+++ b/internal/domain/infra.go
@@ -41,11 +41,25 @@ func InitQuerierInfra(i infra.CommandRunner, path *string, database *string) err
 	return errors.New("path is nil")
 }
 
-func InitRedisInfra(i infra.CommandRunner, path *string) error {
+func InitInMemoryInfra(i infra.CommandRunner, path *string, inMemory *string) error {
 	if path != nil {
 		folderName := "/internal/infra/cache"
-		fileName := folderName + "/redis.go"
-		if err := pkg.GoFileGenerator(i, path, folderName, fileName, infra_template.RedisInfraTemplate); err != nil {
+		var fileName, template string
+		switch *inMemory {
+		case "redis":
+			fileName = folderName + "/redis_infra.go"
+			template = infra_template.RedisInfraTemplate
+		case "valkey":
+			fileName = folderName + "/valkey_infra.go"
+			template = infra_template.ValkeyInfraTemplate
+		case "keydb":
+			fileName = folderName + "/keydb.go"
+			// template = cache_template.RedisConfigTemplate
+		case "dragonfly":
+			fileName = folderName + "/dragonfly.go"
+			// template = cache_template.RedisConfigTemplate
+		}
+		if err := pkg.GoFileGenerator(i, path, folderName, fileName, template); err != nil {
 			log.Fatal(err)
 			return err
 		}

--- a/internal/domain/infra.go
+++ b/internal/domain/infra.go
@@ -52,16 +52,15 @@ func InitInMemoryInfra(i infra.CommandRunner, path *string, inMemory *string) er
 		case "valkey":
 			fileName = folderName + "/valkey_infra.go"
 			template = infra_template.ValkeyInfraTemplate
-		case "keydb":
-			fileName = folderName + "/keydb.go"
-			// template = cache_template.RedisConfigTemplate
 		case "dragonfly":
-			fileName = folderName + "/dragonfly.go"
-			// template = cache_template.RedisConfigTemplate
+			fileName = folderName + "/dragonfly_infra.go"
+			template = infra_template.DragonFlyInfraTemplate
 		}
-		if err := pkg.GoFileGenerator(i, path, folderName, fileName, template); err != nil {
-			log.Fatal(err)
-			return err
+		if fileName != "" || template != "" {
+			if err := pkg.GoFileGenerator(i, path, folderName, fileName, template); err != nil {
+				log.Fatal(err)
+				return err
+			}
 		}
 		return nil
 	}
@@ -86,9 +85,11 @@ func InitMQinfra(i infra.CommandRunner, p *Project) error {
 			fileName = folderName + "/sqs_infra.go"
 			template = infra_template.AmazonSQSInfratemplate
 		}
-		if err := pkg.GoFileGenerator(i, p.Path, folderName, fileName, template); err != nil {
-			log.Fatal(err)
-			return err
+		if fileName != "" || template != "" {
+			if err := pkg.GoFileGenerator(i, p.Path, folderName, fileName, template); err != nil {
+				log.Fatal(err)
+				return err
+			}
 		}
 		return nil
 	}

--- a/internal/domain/main-gen.go
+++ b/internal/domain/main-gen.go
@@ -14,9 +14,11 @@ func InitDependencyInjection(i infra.CommandRunner, p *Project) error {
 		folderName := "/cmd/di"
 		fileName := folderName + "/container.go"
 		var st struct {
-			DBConnection string
-			MQInit       string
-			MQInfra      string
+			DBConnection    string
+			MQInit          string
+			MQInfra         string
+			CacheConnection string
+			CacheInfra      string
 		}
 		switch p.Database {
 		case "postgresql", "mariadb", "clickhouse":
@@ -51,6 +53,15 @@ func InitDependencyInjection(i infra.CommandRunner, p *Project) error {
 		}
 		st.MQInit = provideMQDefault
 
+		switch p.InMemory {
+		case "redis":
+			st.CacheConnection = "NewRedisConnection"
+			st.CacheInfra = "NewRedisCache"
+		case "valkey":
+			st.CacheConnection = "NewValkeyConnection"
+			st.CacheInfra = "NewValkeyCache"
+		}
+
 		template, err := pkg.ParseTemplate(main_template.DITemplate, st)
 		if err != nil {
 			log.Fatal(err)
@@ -82,7 +93,7 @@ func InitServer(i infra.CommandRunner, p *Project) error {
 	if p.Path != nil {
 		folderName := "/cmd/server"
 		fileName := folderName + "/server.go"
-		c, err := pkg.HTTPServerParser(p.Framework, p.Database, p.MQ)
+		c, err := pkg.HTTPServerParser(p.Framework, p.Database, p.MQ, p.InMemory)
 		if err != nil {
 			log.Fatal(err)
 			return err

--- a/internal/domain/main-gen.go
+++ b/internal/domain/main-gen.go
@@ -60,6 +60,9 @@ func InitDependencyInjection(i infra.CommandRunner, p *Project) error {
 		case "valkey":
 			st.CacheConnection = "NewValkeyConnection"
 			st.CacheInfra = "NewValkeyCache"
+		case "dragonfly":
+			st.CacheConnection = "NewDragonflyConnection"
+			st.CacheInfra = "NewDragonflyCache"
 		}
 
 		template, err := pkg.ParseTemplate(main_template.DITemplate, st)

--- a/internal/domain/mq.go
+++ b/internal/domain/mq.go
@@ -28,9 +28,11 @@ func InitMQConfig(i infra.CommandRunner, p *Project) error {
 			fileName = folderName + "/sqs.go"
 			template = mq_template.AmazonSQSConfigTemplate
 		}
-		if err := pkg.GoFileGenerator(i, p.Path, folderName, fileName, template); err != nil {
-			log.Fatal(err)
-			return err
+		if fileName != "" || template != "" {
+			if err := pkg.GoFileGenerator(i, p.Path, folderName, fileName, template); err != nil {
+				log.Fatal(err)
+				return err
+			}
 		}
 		return nil
 	}

--- a/internal/domain/project.go
+++ b/internal/domain/project.go
@@ -11,6 +11,7 @@ type Project struct {
 	Framework  string
 	Database   string
 	MQ         string
+	InMemory   string
 	Git        bool
 	Air        bool
 }

--- a/internal/pkg/parser.go
+++ b/internal/pkg/parser.go
@@ -20,7 +20,7 @@ func ParseTemplate(tmplStr string, data interface{}) (string, error) {
 	return buf.String(), nil
 }
 
-func HTTPServerParser(fwk, db, mq string) (string, error) {
+func HTTPServerParser(fwk, db, mq, cache string) (string, error) {
 	var t types.HTTPServerParse
 	switch fwk {
 	case "gin":
@@ -98,6 +98,21 @@ func HTTPServerParser(fwk, db, mq string) (string, error) {
 					logger.Error().Err(err).Msg("Failed to close mq client connection")
 				}
 			}()`
+	}
+
+	switch cache {
+	case "redis":
+		t.CacheImport = `"github.com/redis/go-redis/v9"`
+		t.CacheInstanceType = "*redis.Client"
+		t.CacheCloseConn = `defer func() {
+				if err := cache.Close(); err != nil {
+					logger.Error().Err(err).Msg("Failed to close cache connection")
+				}
+			}()`
+	case "valkey":
+		t.CacheImport = `"github.com/valkey-io/valkey-go"`
+		t.CacheInstanceType = "valkey.Client"
+		t.CacheCloseConn = `defer cache.Close()`
 	}
 
 	return ParseTemplate(main_template.HTTPServerTemplate, t)

--- a/internal/pkg/parser.go
+++ b/internal/pkg/parser.go
@@ -101,7 +101,7 @@ func HTTPServerParser(fwk, db, mq, cache string) (string, error) {
 	}
 
 	switch cache {
-	case "redis":
+	case "redis","dragonfly":
 		t.CacheImport = `"github.com/redis/go-redis/v9"`
 		t.CacheInstanceType = "*redis.Client"
 		t.CacheCloseConn = `defer func() {

--- a/internal/template/cache/dragonfly.go
+++ b/internal/template/cache/dragonfly.go
@@ -1,0 +1,42 @@
+package cache_template
+
+const DragonflyConfigTemplate string = `
+package cache
+import (
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+	"github.com/spf13/viper"
+)
+
+func NewDragonflyConnection(zerolog zerolog.Logger) (*redis.Client, error) {
+	addr := fmt.Sprintf("%s:%s", viper.GetString("dragonfly.address"), viper.GetString("dragonfly.port"))
+	client := redis.NewClient(&redis.Options{
+		Addr:       addr,
+		ClientName: viper.GetString("dragonfly.client_name"),
+		Protocol:   2,
+		Password:   viper.GetString("dragonfly.password"),
+	})
+	if err := client.Ping(context.Background()).Err(); err != nil {
+		zerolog.Fatal().Err(err).Msg("failed to connect to dragonfly")
+	}
+	return client, nil
+}
+`
+
+const DockerComposeDragonflyConfigTemplate string = `
+# dragonfly
+  {{.ProjectName}}_cache:
+    image: ghcr.io/dragonflydb/dragonfly:v1.34.1
+    container_name: {{.ProjectName}}_cache
+    volumes:
+      - {{.ProjectName}}_dragonfly_data:/data
+    restart: unless-stopped
+		ports:
+      - "6379:6379"
+    environment:
+      - CACHE_PASSWORD=${CACHE_PASSWORD}
+    command: ["dragonfly", "--requirepass", "$CACHE_PASSWORD", "--proactor_threads", "2"]
+`
+
+const DockerComposeDragonflyVolumeTemplate string = `
+  {{.ProjectName}}_dragonfly_data: {}`

--- a/internal/template/cache/redis.go
+++ b/internal/template/cache/redis.go
@@ -37,8 +37,8 @@ const DockerComposeRedisConfigTemplate string = `
 		ports:
       - "6379:6379"
     environment:
-      - REDIS_PASSWORD=${REDIS_PASSWORD}
-    command: ["redis-server", "--requirepass", "$REDIS_PASSWORD"]
+      - CACHE_PASSWORD=${CACHE_PASSWORD}
+    command: ["redis-server", "--requirepass", "$CACHE_PASSWORD"]
 `
 
 const DockerComposeRedisVolumeTemplate string = `

--- a/internal/template/cache/valkey.go
+++ b/internal/template/cache/valkey.go
@@ -1,0 +1,45 @@
+package cache_template
+
+const ValkeyConfigTemplate string = `
+package cache
+
+import (
+	"github.com/rs/zerolog"
+	"github.com/spf13/viper"
+	"github.com/valkey-io/valkey-go"
+)
+
+func NewValkeyConnection(logger zerolog.Logger) (valkey.Client, error) {
+	addr := fmt.Sprintf("%s:%s", viper.GetString("valkey.address"), viper.GetString("valkey.port"))
+	client, err := valkey.NewClient(valkey.ClientOption{
+		InitAddress: []string{addr},
+		Username:    viper.GetString("valkey.username"),
+		Password:    viper.GetString("valkey.password"),
+	})
+	if err != nil {
+		logger.Fatal().Err(err).Msg("failed to connect to valkey")
+	}
+	return client, nil
+}
+`
+
+const DockerComposeValkeyConfigTemplate string = `
+# valkey
+  {{.ProjectName}}_cache:
+    image: valkey/valkey:9-alpine3.22
+    container_name: {{.ProjectName}}_cache
+    volumes:
+      - {{.ProjectName}}_valkey_data:/data
+			- ./config/cache/valkey.acl:/etc/valkey/valkey.acl
+    restart: unless-stopped
+		ports:
+      - "6379:6379"
+		command: ["valkey-server", "--aclfile", "/etc/valkey/valkey.acl"]
+`
+
+const DockerComposeValkeyVolumeTemplate string = `
+  {{.ProjectName}}_valkey_data: {}`
+
+const ValkeyConfigFileTemplate string = `user default off
+user username on >password allcommands allkeys
+`

--- a/internal/template/config/cache.yaml.go
+++ b/internal/template/config/cache.yaml.go
@@ -15,3 +15,11 @@ valkey:
   username: "username"
   password: "password"
 `
+
+const DragonFlyYamlConfigTemplate string =`
+dragonfly:
+  address: "localhost"
+  port: "6379"
+  client_name: "your_service/app_name"
+  password: "password"
+`

--- a/internal/template/config/cache.yaml.go
+++ b/internal/template/config/cache.yaml.go
@@ -7,3 +7,11 @@ redis:
   client_name: "your_service/app_name"
   password: "password"
 `
+
+const ValkeyYamlConfigTemplate string = `
+valkey:
+  address: "localhost"
+  port: "6379"
+  username: "username"
+  password: "password"
+`

--- a/internal/template/config/env.go
+++ b/internal/template/config/env.go
@@ -47,8 +47,8 @@ DB_NAME=
 MQ_USER=
 MQ_PASSWORD=
 
-# redis env
-REDIS_PASSWORD=
+# cache env
+CACHE_PASSWORD=
 
 # minio env
 MINIO_ROOT_USER=

--- a/internal/template/infra/cache.go
+++ b/internal/template/infra/cache.go
@@ -125,3 +125,61 @@ func (v *valkeInfra) Delete(ctx context.Context, key string) error {
 	return nil
 }
 `
+const DragonFlyInfraTemplate string =`
+package cache_infra
+
+import (
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+)
+
+type (
+	DragonflyInfra interface {
+		Set(ctx context.Context, key string, value interface{}, expiration time.Duration) error
+		Get(ctx context.Context, key string) (string, error)
+		Delete(ctx context.Context, key string) error
+	}
+	dragonflyInfra struct {
+		dragonflyClient *redis.Client
+		logger      zerolog.Logger
+	}
+)
+
+func NewDragonflyCache(dragonflyClient *redis.Client, logger zerolog.Logger) DragonflyInfra {
+	return &dragonflyInfra{
+		dragonflyClient: dragonflyClient,
+		logger:      logger,
+	}
+}
+
+func (r *dragonflyInfra) Set(ctx context.Context, key string, value interface{}, expiration time.Duration) error {
+	err := r.dragonflyClient.Set(ctx, key, value, expiration).Err()
+	if err != nil {
+		r.logger.Error().Err(err).Str("key", key).Msg("failed to set value in dragonfly")
+		return err
+	}
+	return nil
+}
+
+func (r *dragonflyInfra) Get(ctx context.Context, key string) (string, error) {
+	val, err := r.dragonflyClient.Get(ctx, key).Result()
+	if err != nil {
+		if err == redis.Nil {
+			r.logger.Warn().Str("key", key).Msg("key not found in dragonfly")
+			return "", err
+		}
+		r.logger.Error().Err(err).Str("key", key).Msg("failed to get value from dragonfly")
+		return "", err
+	}
+	return val, nil
+}
+
+func (r *dragonflyInfra) Delete(ctx context.Context, key string) error {
+	err := r.dragonflyClient.Del(ctx, key).Err()
+	if err != nil {
+		r.logger.Error().Err(err).Str("key", key).Msg("failed to delete key from dragonfly")
+		return err
+	}
+	return nil
+}
+`

--- a/internal/template/main/di.go
+++ b/internal/template/main/di.go
@@ -31,16 +31,16 @@ func BuildContainer() *dig.Container {
 	if err := container.Provide(storage.{{.DBConnection}}); err != nil {
 		panic("Failed to provide db connection: " + err.Error())
 	}
-	// redis connection
-	if err := container.Provide(cache.NewRedisConnection); err != nil {
-		panic("Failed to provide redis connection: " + err.Error())
+	//  connection
+	if err := container.Provide(cache.{{.CacheConnection}}); err != nil {
+		panic("Failed to provide cache connection: " + err.Error())
 	}
 
 	// you can add your own handler, service, repository,infra, or even 
 	// your own defined config here and invoke in the /cmd/server/http_server.go 
 	
 	// infra
-	if err := container.Provide(cache_infra.NewRedisCache); err != nil {
+	if err := container.Provide(cache_infra.{{.CacheInfra}}); err != nil {
 		panic("Failed to provide redis infra: " + err.Error())
 	}	
 	if err := container.Provide(mq_infra.{{.MQInfra}}); err != nil {

--- a/internal/template/main/server.go
+++ b/internal/template/main/server.go
@@ -7,8 +7,7 @@ import (
 	{{.FrameworkImport}}
 	{{.DBImport}}
 	{{.MQImport}}
-	
-	"github.com/redis/go-redis/v9"
+	{{.CacheImport}}
 	"github.com/rs/zerolog"
 	"go.uber.org/dig"
 )
@@ -24,18 +23,14 @@ func (s *Server) Run(ctx context.Context) {
 		func(
 			logger zerolog.Logger,
 			r {{.FrameworkRouter}},
-			redis *redis.Client,
+			cache {{.CacheInstanceType}},
 			{{.MQInstance}}
 			db {{.DBInstanceType}},
 			th handler.TodoHandler,
 			// and many other returned type provided
 			// in the container from /cmd/di/container.go
 		) {
-			defer func() {
-				if err := redis.Close(); err != nil {
-					logger.Error().Err(err).Msg("Failed to close Redis client")
-				}
-			}()
+			{{.CacheCloseConn}}
 			{{.MQCloseConn}}
 			defer {{.DBCloseConnection}}
 			

--- a/internal/template/readme/readme.md
+++ b/internal/template/readme/readme.md
@@ -32,7 +32,7 @@ MQ_USER=user
 MQ_PASSWORD=password
 
 # redis env
-REDIS_PASSWORD=password
+CACHE_PASSWORD=password
 
 # minio env
 MINIO_ROOT_USER=ROOTUSER

--- a/internal/template/readme/readme.md
+++ b/internal/template/readme/readme.md
@@ -68,9 +68,10 @@ make run
 ```
 
 > [!NOTE]
-> If you use windows and generate the project using wsl, the hot reload won't work. better you use the fndn for windows in this case or if its already generated, you can change the .air.toml in **cmd part** to become like below and **run air from windows**, not from wsl.
+> If you use windows and generate the project using wsl, the hot reload won't work. better you use the fndn for windows in this case or if its already generated, you can change the .air.toml in `bin and cmd` part to become like below and **run air from windows**, not from wsl.
 >
 > ```yml
+> bin = "./tmp/main.exe"
 > cmd = "go build -o ./tmp/main.exe ./cmd"
 > ```
 

--- a/internal/types/http_server.go
+++ b/internal/types/http_server.go
@@ -11,5 +11,8 @@ type (
 		MQImport          string
 		MQInstance        string
 		MQCloseConn       string
+		CacheImport       string
+		CacheInstanceType string
+		CacheCloseConn    string
 	}
 )

--- a/internal/ui/input_main.go
+++ b/internal/ui/input_main.go
@@ -71,7 +71,7 @@ func newModel(uc *app.InitProjectUseCase, targetDir string) model {
 		},
 		{
 			Label:    "In-memory Store",
-			Input:    module.NewRadioButton([]string{"Redis", "Valkey", "KeyDB", "Dragonfly"}, 0),
+			Input:    module.NewRadioButton([]string{"Redis", "Valkey", "Dragonfly"}, 0),
 			Validate: nil,
 		},
 	}

--- a/internal/ui/input_main.go
+++ b/internal/ui/input_main.go
@@ -69,6 +69,11 @@ func newModel(uc *app.InitProjectUseCase, targetDir string) model {
 			Input:    module.NewRadioButton([]string{"Nats", "RabbitMQ", "Kafka", "Amazon SQS"}, 0),
 			Validate: nil,
 		},
+		{
+			Label:    "In-memory Store",
+			Input:    module.NewRadioButton([]string{"Redis", "Valkey", "KeyDB", "Dragonfly"}, 0),
+			Validate: nil,
+		},
 	}
 
 	steps[0].Input.Focus()

--- a/internal/ui/input_utility.go
+++ b/internal/ui/input_utility.go
@@ -74,6 +74,8 @@ func (m *model) viewStep() string {
 		s += style.BlueStyle.Render("which database would you working on?\n")
 	case 6:
 		s += style.BlueStyle.Render("which message queue would you connect?\n")
+	case 7:
+		s += style.BlueStyle.Render("which in-memory store would you use?\n")
 	}
 
 	s += "\n"
@@ -107,6 +109,7 @@ func (m *model) submit() tea.Cmd {
 		Framework:  "gin",
 		Database:   "postgresql",
 		MQ:         "nats",
+		InMemory:   "redis",
 	}
 	project.Path = &m.targetDir
 
@@ -132,6 +135,9 @@ func (m *model) submit() tea.Cmd {
 			}
 			if v, ok := m.steps[6].Input.Value().(string); ok {
 				project.MQ = strings.ToLower(v)
+			}
+			if v, ok := m.steps[7].Input.Value().(string); ok {
+				project.InMemory = strings.ToLower(v)
 			}
 		}
 	}


### PR DESCRIPTION
This pull request adds support for multiple in-memory cache backends (Redis, Valkey, and Dragonfly) throughout the project scaffolding and configuration generation. It refactors relevant code and templates to dynamically generate code, configuration files, and Docker Compose setups based on the selected cache backend. Additionally, it improves error handling and updates environment variable naming for clarity.

**Multi-cache backend support and code generation:**

* Added `InMemory` field to the `Project` struct and updated all code generation logic to conditionally generate code, configuration files, and infrastructure for Redis, Valkey, or Dragonfly based on user selection. (`internal/domain/project.go`, `internal/app/init_project.go`, `internal/domain/cache.go`, `internal/domain/infra.go`, `internal/domain/main-gen.go`, `internal/pkg/parser.go`) [[1]](diffhunk://#diff-234c380aa075c33cc312bd6eb28aa0669fe1c0f07eac0a4c76174387530d6b52R14) [[2]](diffhunk://#diff-c22934e1f738caf21192939ea06598f8940a86a79a5f882c39f781bca0e9243aL50-R63) [[3]](diffhunk://#diff-c22934e1f738caf21192939ea06598f8940a86a79a5f882c39f781bca0e9243aL72-R73) [[4]](diffhunk://#diff-c22934e1f738caf21192939ea06598f8940a86a79a5f882c39f781bca0e9243aR153-R156) [[5]](diffhunk://#diff-38ba63a5d215711be6f955681c82a021e2858c20dbd1ab42a0d26a22c5ab2c13L12-R52) [[6]](diffhunk://#diff-a2c2968a31978840a5c22b99fc6fd8a9f2e0abfbba8174efdf9d6e932165881bL44-R64) [[7]](diffhunk://#diff-93836cfaa28a56f7754b200bc4378dcde125b81843e58aecbb68de36c79c8d0eR20-R21) [[8]](diffhunk://#diff-93836cfaa28a56f7754b200bc4378dcde125b81843e58aecbb68de36c79c8d0eR56-R67) [[9]](diffhunk://#diff-0bf7eb746977c182936eb3a52c70c17a199999c061b572e3ad0eb70b46454965L23-R23) [[10]](diffhunk://#diff-0bf7eb746977c182936eb3a52c70c17a199999c061b572e3ad0eb70b46454965R103-R117)

* Added new templates for Valkey and Dragonfly cache backends, including Go code, Docker Compose service and volume definitions, and configuration files. (`internal/template/cache/valkey.go`, `internal/template/cache/dragonfly.go`, `internal/template/config/cache.yaml.go`) [[1]](diffhunk://#diff-10603190dd3a7cb43fb0af96c1de4bcd8489de810db24f0429f9746f486dc3f6R1-R45) [[2]](diffhunk://#diff-6d7be041dd25165146ac8f023b2e11c1e62da7d4c94cbc35a11de0fa412e3fd2R1-R42) [[3]](diffhunk://#diff-7433f0c585fcf057b44b81127aa0049f1a415fdaa18899a3a57b1bf4e311dcbfR10-R25)

**Configuration and Docker Compose improvements:**

* Refactored Docker Compose and YAML config generation to use the appropriate cache backend templates and environment variables (`CACHE_PASSWORD` instead of `REDIS_PASSWORD`). (`internal/domain/docker.go`, `internal/template/cache/redis.go`, `internal/template/config/env.go`, `internal/domain/config.go`) [[1]](diffhunk://#diff-b84348623444c5901ab6ffe428f885f3f335e85047b38480bec0b46b8ec59a74L51-L53) [[2]](diffhunk://#diff-b84348623444c5901ab6ffe428f885f3f335e85047b38480bec0b46b8ec59a74R66-R67) [[3]](diffhunk://#diff-b84348623444c5901ab6ffe428f885f3f335e85047b38480bec0b46b8ec59a74R78-R104) [[4]](diffhunk://#diff-25a4b9421c03782d62a6c84c83baf11026294c5be0be52245602a29670b98ccbL40-R41) [[5]](diffhunk://#diff-8665c6b5587c3b894594bbc6c241a2a49ce8a6ced63b86ac79459ff3ff8b1f59L50-R51) [[6]](diffhunk://#diff-a4f968b05e19215e42106153851095c6d617894089bfc27b0a213f6a3bc6b991R48-R55)

**Dependency injection and server setup:**

* Updated dependency injection and server setup code to support cache backend selection, including proper imports, instance types, and connection closing logic. (`internal/domain/main-gen.go`, `internal/pkg/parser.go`) [[1]](diffhunk://#diff-93836cfaa28a56f7754b200bc4378dcde125b81843e58aecbb68de36c79c8d0eL85-R99) [[2]](diffhunk://#diff-0bf7eb746977c182936eb3a52c70c17a199999c061b572e3ad0eb70b46454965L23-R23) [[3]](diffhunk://#diff-0bf7eb746977c182936eb3a52c70c17a199999c061b572e3ad0eb70b46454965R103-R117)

**Error handling and template generation robustness:**

* Improved error handling in template generation functions for cache and MQ backends, ensuring code only runs when templates and filenames are set. (`internal/domain/cache.go`, `internal/domain/infra.go`, `internal/domain/mq.go`) [[1]](diffhunk://#diff-38ba63a5d215711be6f955681c82a021e2858c20dbd1ab42a0d26a22c5ab2c13L12-R52) [[2]](diffhunk://#diff-a2c2968a31978840a5c22b99fc6fd8a9f2e0abfbba8174efdf9d6e932165881bR88-R93) [[3]](diffhunk://#diff-dad0f24129da4409812dc89bd896d7fd691c6987b8bf8f85e3b5ad5cd0914473R31-R36)

**Documentation and release process:**

* Updated documentation to clarify cache backend setup for Windows/WSL users and improved changelog exclusion rules in `.goreleaser.yaml`. (`README.MD`, `.goreleaser.yaml`) [[1]](diffhunk://#diff-01e6d9ffed056a02cae8d8a0ec5d476a64d017bf85c0d5a94bb23ca21f33f5aaL199-R202) [[2]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826R58)