### PR TITLE
Feat: Add redict to in-memory option

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -80,6 +80,7 @@ Currently, the generation are in default mode and custom mode with limitation at
 ![Redis](https://img.shields.io/badge/redis-%23DD0031.svg?&style=for-the-badge&logo=redis&logoColor=white)
 ![Valkey](https://img.shields.io/badge/valkey-2D2471?style=for-the-badge&logo=valkey&logoColor=white)
 ![Dragonfly](https://img.shields.io/badge/Dragonfly-0B0514?style=for-the-badge&logo=dragonfly&logoColor=white)
+![Redict](https://img.shields.io/badge/Redict-800000?style=for-the-badge&logo=Redict&logoColor=white)
 
 - Object Storage
 

--- a/internal/domain/cache.go
+++ b/internal/domain/cache.go
@@ -23,6 +23,9 @@ func InitInMemoryConfig(i infra.CommandRunner, path *string, inMemory *string) e
 		case "dragonfly":
 			fileName = folderName + "/dragonfly.go"
 			template = cache_template.DragonflyConfigTemplate
+		case "redict":
+			fileName = folderName + "/redict.go"
+			template = cache_template.RedictConfigTemplate
 		}
 		if fileName != "" || template != "" {
 			if err := pkg.GoFileGenerator(i, path, folderName, fileName, template); err != nil {

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -52,6 +52,8 @@ func InitYamlConfig(i infra.CommandRunner, p *Project) error {
 			s += config_template.ValkeyYamlConfigTemplate
 		case "dragonfly":
 			s += config_template.DragonFlyYamlConfigTemplate
+		case "redict":
+			s += config_template.RedictYamlConfigTemplate
 		}
 
 		switch p.MQ {

--- a/internal/domain/docker.go
+++ b/internal/domain/docker.go
@@ -89,6 +89,9 @@ func InitDockerComposeConfig(i infra.CommandRunner, p *Project) error {
 		case "dragonfly":
 			cacheDockerTemplate = cache_template.DockerComposeDragonflyConfigTemplate
 			cacheVolumeTemplate = cache_template.DockerComposeDragonflyVolumeTemplate
+		case "redict":
+			cacheDockerTemplate = cache_template.DockerComposeRedictConfigTemplate
+			cacheVolumeTemplate = cache_template.DockerComposeRedictVolumeTemplate
 		}
 
 		templates := []string{

--- a/internal/domain/infra.go
+++ b/internal/domain/infra.go
@@ -55,6 +55,9 @@ func InitInMemoryInfra(i infra.CommandRunner, path *string, inMemory *string) er
 		case "dragonfly":
 			fileName = folderName + "/dragonfly_infra.go"
 			template = infra_template.DragonFlyInfraTemplate
+		case "redict":
+			fileName = folderName + "/redict_infra.go"
+			template = infra_template.RedictInfraTemplate
 		}
 		if fileName != "" || template != "" {
 			if err := pkg.GoFileGenerator(i, path, folderName, fileName, template); err != nil {

--- a/internal/domain/main-gen.go
+++ b/internal/domain/main-gen.go
@@ -63,6 +63,9 @@ func InitDependencyInjection(i infra.CommandRunner, p *Project) error {
 		case "dragonfly":
 			st.CacheConnection = "NewDragonflyConnection"
 			st.CacheInfra = "NewDragonflyCache"
+		case "redict":
+			st.CacheConnection = "NewRedictConnection"
+			st.CacheInfra = "NewRedictCache"
 		}
 
 		template, err := pkg.ParseTemplate(main_template.DITemplate, st)

--- a/internal/pkg/parser.go
+++ b/internal/pkg/parser.go
@@ -101,7 +101,7 @@ func HTTPServerParser(fwk, db, mq, cache string) (string, error) {
 	}
 
 	switch cache {
-	case "redis","dragonfly":
+	case "redis","dragonfly","redict":
 		t.CacheImport = `"github.com/redis/go-redis/v9"`
 		t.CacheInstanceType = "*redis.Client"
 		t.CacheCloseConn = `defer func() {

--- a/internal/template/cache/redict.go
+++ b/internal/template/cache/redict.go
@@ -1,0 +1,52 @@
+package cache_template
+
+const RedictConfigTemplate = `
+package cache
+
+import (
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+	"github.com/spf13/viper"
+)
+
+func NewRedictConnection(zerolog zerolog.Logger) (*redis.Client, error) {
+	addr := fmt.Sprintf("%s:%s", viper.GetString("redict.address"), viper.GetString("redict.port"))
+	client := redis.NewClient(&redis.Options{
+		Addr:       addr,
+		ClientName: viper.GetString("redict.client_name"),
+		Protocol:   2,
+		Password:   viper.GetString("redict.password"),
+	})
+
+	ctx := context.Background()
+	if err := client.Ping(ctx).Err(); err != nil {
+		zerolog.Fatal().Err(err).Msg("failed to connect to redis")
+	}
+	return client, nil
+}
+`
+const DockerComposeRedictConfigTemplate = `
+# redict
+	{{.ProjectName}}_cache:
+		image: registry.redict.io/redict:7.3.6-scratch
+		container_name: {{.ProjectName}}_cache
+		volumes:
+			- {{.ProjectName}}_redict_data:/data
+		restart: unless-stopped
+		ports:
+			- "6379:6379"
+		environment:
+			- CACHE_PASSWORD=${CACHE_PASSWORD}
+		command:
+			[
+				"redict-server",
+				"--requirepass",
+				"$CACHE_PASSWORD",
+				"--maxmemory",
+				"512mb",
+				"--maxmemory-policy",
+				"allkeys-lru",
+			]
+`
+const DockerComposeRedictVolumeTemplate string = `
+  {{.ProjectName}}_redict_data: {}`

--- a/internal/template/config/cache.yaml.go
+++ b/internal/template/config/cache.yaml.go
@@ -23,3 +23,11 @@ dragonfly:
   client_name: "your_service/app_name"
   password: "password"
 `
+
+const RedictYamlConfigTemplate string =`
+redict:
+  address: "localhost"
+  port: "6379"
+  client_name: "your_service/app_name"
+  password: "password"
+`

--- a/internal/ui/input_main.go
+++ b/internal/ui/input_main.go
@@ -71,7 +71,7 @@ func newModel(uc *app.InitProjectUseCase, targetDir string) model {
 		},
 		{
 			Label:    "In-memory Store",
-			Input:    module.NewRadioButton([]string{"Redis", "Valkey", "Dragonfly"}, 0),
+			Input:    module.NewRadioButton([]string{"Redis", "Valkey", "Dragonfly", "Redict"}, 0),
 			Validate: nil,
 		},
 	}


### PR DESCRIPTION
This pull request adds support for Redict as a new in-memory cache backend throughout the codebase. The changes ensure that Redict can be selected and configured similarly to existing cache options like Redis and Dragonfly, with corresponding templates, dependency injection, and Docker Compose support.

**Redict cache backend integration:**

* Added Redict as a selectable in-memory store in the UI (`internal/ui/input_main.go`).
* Updated configuration logic to handle Redict for in-memory config, YAML config, and Docker Compose setup (`internal/domain/cache.go`, `internal/domain/config.go`, `internal/domain/docker.go`). [[1]](diffhunk://#diff-38ba63a5d215711be6f955681c82a021e2858c20dbd1ab42a0d26a22c5ab2c13R26-R28) [[2]](diffhunk://#diff-a4f968b05e19215e42106153851095c6d617894089bfc27b0a213f6a3bc6b991R55-R56) [[3]](diffhunk://#diff-b84348623444c5901ab6ffe428f885f3f335e85047b38480bec0b46b8ec59a74R92-R94)
* Incorporated Redict into dependency injection and parser logic, ensuring proper connection and type handling (`internal/domain/main-gen.go`, `internal/pkg/parser.go`). [[1]](diffhunk://#diff-93836cfaa28a56f7754b200bc4378dcde125b81843e58aecbb68de36c79c8d0eR66-R68) [[2]](diffhunk://#diff-0bf7eb746977c182936eb3a52c70c17a199999c061b572e3ad0eb70b46454965L104-R104)

**Template additions for Redict:**

* Introduced Redict-specific templates for Go config, Docker Compose, and YAML configuration (`internal/template/cache/redict.go`, `internal/template/config/cache.yaml.go`). [[1]](diffhunk://#diff-93d3d8f818887088100e4e54c81d6a82d802633004e980884338ea195a1aa0d3R1-R52) [[2]](diffhunk://#diff-7433f0c585fcf057b44b81127aa0049f1a415fdaa18899a3a57b1bf4e311dcbfR26-R33)
* Added Redict infrastructure template for cache operations (`internal/template/infra/cache.go`).

**Documentation update:**

* Updated the `README.MD` to include Redict in the list of supported cache backends.