### PR TITLE
Version: Roll out to go v1.25.8 and update to minimum go usage

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -17,6 +17,9 @@ Bootstrap your Go projects with clean architecture, best practices, and a solid 
 
 > [!NOTE]
 > v0.7.0 now is stable, latest version, and generating one set of application with its driver to 3rd party. in this version, you can generate different framework, database, message queue, in-memory store, and object storage.
+## 📋 Prerequisites
+
+Go Version: >= v1.25.0
 
 ## 🔥 Get started
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/daffadon/fndn
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/charmbracelet/bubbles v0.21.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/daffadon/fndn
 
-go 1.24.9
+go 1.25.0
 
 require (
 	github.com/charmbracelet/bubbles v0.21.0


### PR DESCRIPTION
This pull request introduces updates to the project's prerequisites and Go version requirements, ensuring compatibility with newer Go releases and clarifying setup instructions.

Project prerequisites and setup:

* Added a new "Prerequisites" section to the `README.MD`, specifying that Go version 1.25.0 or higher is required.

Go version update:

* Updated the Go version in `go.mod` from `1.24.9` to `1.25.8` to align with the new prerequisites and support the latest features.